### PR TITLE
[Refactor] #303 NavigationLink를 Router로 대체

### DIFF
--- a/Macro/Screen/HomeScreen/HomeView.swift
+++ b/Macro/Screen/HomeScreen/HomeView.swift
@@ -72,8 +72,10 @@ struct HomeView: View {
                             VStack {
                                 LazyVGrid(columns: columns, spacing: 8) {
                                     ForEach(self.appState.selectedInstrument.defaultJangdans, id: \.self) { jangdan in
-                                        NavigationLink(jangdan.name, destination: BuiltinJangdanPracticeView(viewModel: DIContainer.shared.builtInJangdanPracticeViewModel, jangdanName: jangdan.rawValue))
-                                            .buttonStyle(JangdanLogoButtonStyle(jangdan: jangdan))
+                                        Button(jangdan.name) {
+                                            self.router.push(.builtInJangdanPractice(jangdanName: jangdan.name))
+                                        }
+                                        .buttonStyle(JangdanLogoButtonStyle(jangdan: jangdan))
                                     }
                                 }
                             }

--- a/Macro/System/Router.swift
+++ b/Macro/System/Router.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 enum Route: Hashable {
     case customJangdanList
+    case builtInJangdanPractice(jangdanName: String)
     case jangdanTypeSelect
     case customJangdanCreate(jangdanName: String)
     case customJangdanPractice(jangdanName: String, jangdanType: String)
@@ -22,6 +23,8 @@ class Router {
         switch route {
         case .customJangdanList:
             return AnyView(CustomJangdanListView(viewModel: DIContainer.shared.customJangdanListViewModel))
+        case let .builtInJangdanPractice(jangdanName):
+            return AnyView(BuiltinJangdanPracticeView(viewModel: DIContainer.shared.builtInJangdanPracticeViewModel, jangdanName: jangdanName))
         case .jangdanTypeSelect:
             return AnyView(JangdanTypeSelectView())
         case let .customJangdanCreate(jangdanName):


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
HomeView에서 사용하고있던 NavigationLink를 Router 사용으로 대체합니다.
- 네비게이션 로직을 Router로 통일함으로써 코드의 일관성 유지
- NavigationLink 대신 Button으로 변경함으로써 화면 전환시 로직 추가 가능해짐

<!-- Close #303  -->

## 작업 내용
### 1. Route 추가
- JangdanName: String 을 연관값으로 받는 경로 추가

### 2. NavigationLink -> Button
- ButtonStyle 적용한 Button으로 변경

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
NavigationLink를 Button으로 변경해서
버튼을 탭할때 로직을 추가할 수 있게 되었는데
Jangdan을 fetch해오는 로직을 MetronomeView의 .onAppear() 에서 HomeView의 Button으로 옮기는것에 대해 어떻게 생각하시나요?

Jangdan을 fetch 해오는 로직은 비즈니스 로직이라고 생각해서 (암튼 화면이랑은 상관 없는것 같음)
언젠가는 ViewModel 레이어로 넘겨야 하지 않을까 고민중입니다만
당장은 MetronomeView에서 fetch 로직을 제거하는 목적입니다