### PR TITLE
[Fix] #311 재생 여부가 화면을 벗어나도 초기화되지 않는 오류

### DIFF
--- a/Macro/Domain/UseCase/Interface/MetronomeOnOffUseCase.swift
+++ b/Macro/Domain/UseCase/Interface/MetronomeOnOffUseCase.swift
@@ -5,7 +5,11 @@
 //  Created by leejina on 11/8/24.
 //
 
+import Combine
+
 protocol MetronomeOnOffUseCase {
+    var isPlayingPublisher: AnyPublisher<Bool, Never> { get }
+    
     func changeSobak()
     func play(_ tickHandler: @escaping () -> Void )
     func stop()

--- a/Macro/Domain/UseCase/Interface/MetronomeOnOffUseCase.swift
+++ b/Macro/Domain/UseCase/Interface/MetronomeOnOffUseCase.swift
@@ -9,9 +9,10 @@ import Combine
 
 protocol MetronomeOnOffUseCase {
     var isPlayingPublisher: AnyPublisher<Bool, Never> { get }
+    var tickPublisher: AnyPublisher<Void, Never> { get }
     
     func changeSobak()
-    func play(_ tickHandler: @escaping () -> Void )
+    func play()
     func stop()
     func setSoundType()
 }

--- a/Macro/Domain/UseCase/MetronomeOnOffImplement.swift
+++ b/Macro/Domain/UseCase/MetronomeOnOffImplement.swift
@@ -90,12 +90,16 @@ extension MetronomeOnOffImplement: MetronomeOnOffUseCase {
         
         // Timer 실행
         self.timer?.resume()
+        // play 여부 publish
+        self.isPlayingSubject.send(true)
     }
     
     func stop() {
         UIApplication.shared.isIdleTimerDisabled = false
         self.timer?.cancel()
         self.timer = nil
+        // stop 여부 publish
+        self.isPlayingSubject.send(false)
     }
     
     func setSoundType() {

--- a/Macro/Domain/UseCase/MetronomeOnOffImplement.swift
+++ b/Macro/Domain/UseCase/MetronomeOnOffImplement.swift
@@ -23,6 +23,7 @@ class MetronomeOnOffImplement {
     private var currentBeatIndex: Int
     var isSobakOn: Bool
     
+    private var isPlayingSubject: PassthroughSubject<Bool, Never> = .init()
     var cancelBag: Set<AnyCancellable> = []
     
     // timer
@@ -63,6 +64,10 @@ class MetronomeOnOffImplement {
 
 // Play / Stop
 extension MetronomeOnOffImplement: MetronomeOnOffUseCase {
+    var isPlayingPublisher: AnyPublisher<Bool, Never> {
+        self.isPlayingSubject.eraseToAnyPublisher()
+    }
+    
     
     func changeSobak() {
         self.isSobakOn.toggle()

--- a/Macro/Domain/UseCase/MetronomeOnOffImplement.swift
+++ b/Macro/Domain/UseCase/MetronomeOnOffImplement.swift
@@ -91,10 +91,10 @@ extension MetronomeOnOffImplement: MetronomeOnOffUseCase {
             self.timerHandler()
         }
         
-        // Timer 실행
-        self.timer?.resume()
         // play 여부 publish
         self.isPlayingSubject.send(true)
+        // Timer 실행
+        self.timer?.resume()
     }
     
     func stop() {
@@ -110,10 +110,11 @@ extension MetronomeOnOffImplement: MetronomeOnOffUseCase {
     }
     
     private func timerHandler() {
+        // timer 틱마다 publish
+        self.tickSubject.send()
+        
         let accent: Accent = jangdanAccentList[self.currentBeatIndex % jangdanAccentList.count]
         self.soundManager.beep(accent)
         self.currentBeatIndex += 1
-        // timer 틱마다 publish
-        self.tickSubject.send()
     }
 }

--- a/Macro/Domain/UseCase/MetronomeOnOffImplement.swift
+++ b/Macro/Domain/UseCase/MetronomeOnOffImplement.swift
@@ -21,10 +21,10 @@ class MetronomeOnOffImplement {
     
     private var bpm: Double
     private var currentBeatIndex: Int
-    var isSobakOn: Bool
+    private var isSobakOn: Bool
     
     private var isPlayingSubject: PassthroughSubject<Bool, Never> = .init()
-    var cancelBag: Set<AnyCancellable> = []
+    private var cancelBag: Set<AnyCancellable> = []
     
     // timer
     private var timer: DispatchSourceTimer?

--- a/Macro/Domain/UseCase/MetronomeOnOffImplement.swift
+++ b/Macro/Domain/UseCase/MetronomeOnOffImplement.swift
@@ -24,6 +24,7 @@ class MetronomeOnOffImplement {
     private var isSobakOn: Bool
     
     private var isPlayingSubject: PassthroughSubject<Bool, Never> = .init()
+    private var tickSubject: PassthroughSubject<Void, Never> = .init()
     private var cancelBag: Set<AnyCancellable> = []
     
     // timer
@@ -68,12 +69,15 @@ extension MetronomeOnOffImplement: MetronomeOnOffUseCase {
         self.isPlayingSubject.eraseToAnyPublisher()
     }
     
+    var tickPublisher: AnyPublisher<Void, Never> {
+        self.tickSubject.eraseToAnyPublisher()
+    }
     
     func changeSobak() {
         self.isSobakOn.toggle()
     }
     
-    func play(_ tickHandler: @escaping () -> Void ) {
+    func play() {
         // 데이터 갱신
         self.currentBeatIndex = 0
         UIApplication.shared.isIdleTimerDisabled = true
@@ -84,7 +88,6 @@ extension MetronomeOnOffImplement: MetronomeOnOffUseCase {
         self.timer?.setEventHandler { [weak self] in
             guard let self = self else { return }
             self.lastPlayTime = .now
-            tickHandler()
             self.timerHandler()
         }
         
@@ -110,5 +113,7 @@ extension MetronomeOnOffImplement: MetronomeOnOffUseCase {
         let accent: Accent = jangdanAccentList[self.currentBeatIndex % jangdanAccentList.count]
         self.soundManager.beep(accent)
         self.currentBeatIndex += 1
+        // timer 틱마다 publish
+        self.tickSubject.send()
     }
 }

--- a/Macro/Screen/MetronomeScreen/MetronomeControlView.swift
+++ b/Macro/Screen/MetronomeScreen/MetronomeControlView.swift
@@ -10,8 +10,7 @@ import Combine
 
 struct MetronomeControlView: View {
     
-    @State var viewModel: MetronomeViewModel
-    @State var controlViewModel = DIContainer.shared.controlViewModel
+    @State var viewModel: MetronomeControlViewModel = DIContainer.shared.controlViewModel
     private let threshold: CGFloat = 10 // 드래그 시 숫자변동 빠르기 조절 위한 변수
     @State private var tapFeedback: Int = 0
     @State private var isChangeBpm: Bool = false
@@ -25,7 +24,7 @@ struct MetronomeControlView: View {
                         .foregroundStyle(.backgroundCard)
                     
                     VStack(alignment: .center, spacing: 10) {
-                        if !self.controlViewModel.state.isTapping {
+                        if !self.viewModel.state.isTapping {
                             Text("빠르기(BPM)")
                                 .font(.Callout_R)
                                 .foregroundStyle(.textTertiary)
@@ -42,7 +41,7 @@ struct MetronomeControlView: View {
                         
                         HStack(spacing: 12) {
                             Circle()
-                                .fill(controlViewModel.state.isMinusActive ? .buttonBPMControlActive : .buttonBPMControlDefault)
+                                .fill(self.viewModel.state.isMinusActive ? .buttonBPMControlActive : .buttonBPMControlDefault)
                                 .frame(width: 56)
                                 .overlay {
                                     Image(systemName: "minus")
@@ -58,16 +57,16 @@ struct MetronomeControlView: View {
                                     tapTwiceAction(isIncreasing: false, isPressing: isPressing)
                                 }, perform: {})
                             
-                            Text("\(controlViewModel.state.bpm)")
+                            Text("\(self.viewModel.state.bpm)")
                                 .font(.custom("Pretendard-Medium", fixedSize: 64))
-                                .foregroundStyle(self.controlViewModel.state.isTapping ? .textBPMSearch : .textSecondary)
+                                .foregroundStyle(self.viewModel.state.isTapping ? .textBPMSearch : .textSecondary)
                                 .frame(width: 120, height: 60)
                                 .padding(8)
-                                .background(self.controlViewModel.state.isTapping ? .backgroundDefault : .clear)
+                                .background(self.viewModel.state.isTapping ? .backgroundDefault : .clear)
                                 .cornerRadius(16)
                             
                             Circle()
-                                .fill(controlViewModel.state.isPlusActive ? .buttonBPMControlActive : .buttonBPMControlDefault)
+                                .fill(self.viewModel.state.isPlusActive ? .buttonBPMControlActive : .buttonBPMControlDefault)
                                 .frame(width: 56)
                                 .overlay {
                                     Image(systemName: "plus")
@@ -83,7 +82,7 @@ struct MetronomeControlView: View {
                                     tapTwiceAction(isIncreasing: true, isPressing: isPressing)
                                 }, perform: {})
                         }
-                        .sensoryFeedback(.selection, trigger: self.controlViewModel.state.bpm) { _, _ in
+                        .sensoryFeedback(.selection, trigger: self.viewModel.state.bpm) { _, _ in
                             return isChangeBpm
                         }
                     }
@@ -114,15 +113,15 @@ struct MetronomeControlView: View {
                             self.viewModel.effect(action: .changeIsPlaying)
                         }
                     
-                    Text(self.controlViewModel.state.isTapping ? "탭" : "빠르기\n찾기")
-                        .font(self.controlViewModel.state.isTapping ? .custom("Pretendard-Regular", size: 28) : .custom("Pretendard-Regular", size: 17))
+                    Text(self.viewModel.state.isTapping ? "탭" : "빠르기\n찾기")
+                        .font(self.viewModel.state.isTapping ? .custom("Pretendard-Regular", size: 28) : .custom("Pretendard-Regular", size: 17))
                         .multilineTextAlignment(.center)
-                        .foregroundStyle(self.controlViewModel.state.isTapping ? .textButtonEmphasis : .textButtonPrimary)
+                        .foregroundStyle(self.viewModel.state.isTapping ? .textButtonEmphasis : .textButtonPrimary)
                         .frame(width: 120, height: 80)
-                        .background(self.controlViewModel.state.isTapping ? .buttonActive : .buttonPrimary)
+                        .background(self.viewModel.state.isTapping ? .buttonActive : .buttonPrimary)
                         .clipShape(RoundedRectangle(cornerRadius: 100))
                         .onTapGesture {
-                            self.controlViewModel.effect(action: .estimateBpm)
+                            self.viewModel.effect(action: .estimateBpm)
                             self.tapFeedback += 1
                         }
                         .sensoryFeedback(.impact(flexibility: .rigid), trigger: self.tapFeedback)
@@ -137,18 +136,18 @@ struct MetronomeControlView: View {
     }
     
     private func startTimer(isIncreasing: Bool) {
-        controlViewModel.effect(action: .setSpeed(speed: 0.5))
+        self.viewModel.effect(action: .setSpeed(speed: 0.5))
         stopTimer()
-        controlViewModel.timerCancellable = Timer.publish(every: controlViewModel.state.speed, on: .main, in: .common)
+        self.viewModel.timerCancellable = Timer.publish(every: self.viewModel.state.speed, on: .main, in: .common)
             .autoconnect()
             .sink { _ in
                 if isIncreasing {
-                    self.controlViewModel.effect(action: .increaseLongBpm(currentBpm: controlViewModel.state.bpm))
-                    controlViewModel.effect(action: .setSpeed(speed: max(0.08, controlViewModel.state.speed * 0.5)))
+                    self.viewModel.effect(action: .increaseLongBpm(currentBpm: self.viewModel.state.bpm))
+                    self.viewModel.effect(action: .setSpeed(speed: max(0.08, self.viewModel.state.speed * 0.5)))
                     restartTimer(isIncreasing: isIncreasing)
                 } else {
-                    self.controlViewModel.effect(action: .decreaseLongBpm(currentBpm: controlViewModel.state.bpm))
-                    controlViewModel.effect(action: .setSpeed(speed: max(0.08, controlViewModel.state.speed * 0.5)))
+                    self.viewModel.effect(action: .decreaseLongBpm(currentBpm: self.viewModel.state.bpm))
+                    self.viewModel.effect(action: .setSpeed(speed: max(0.08, self.viewModel.state.speed * 0.5)))
                     restartTimer(isIncreasing: isIncreasing)
                 }
             }
@@ -157,38 +156,38 @@ struct MetronomeControlView: View {
     
     private func restartTimer(isIncreasing: Bool) {
         stopTimer()
-        controlViewModel.timerCancellable = Timer.publish(every: controlViewModel.state.speed, on: .main, in: .common)
+        self.viewModel.timerCancellable = Timer.publish(every: self.viewModel.state.speed, on: .main, in: .common)
             .autoconnect()
             .sink { _ in
                 if isIncreasing {
-                    self.controlViewModel.effect(action: .increaseLongBpm(currentBpm: controlViewModel.state.bpm))
-                    controlViewModel.effect(action: .setSpeed(speed: max(0.08, controlViewModel.state.speed * 0.5)))
+                    self.viewModel.effect(action: .increaseLongBpm(currentBpm: self.viewModel.state.bpm))
+                    self.viewModel.effect(action: .setSpeed(speed: max(0.08, self.viewModel.state.speed * 0.5)))
                     restartTimer(isIncreasing: isIncreasing)
                 } else {
-                    self.controlViewModel.effect(action: .decreaseLongBpm(currentBpm: controlViewModel.state.bpm))
-                    controlViewModel.effect(action: .setSpeed(speed: max(0.08, controlViewModel.state.speed * 0.5)))
+                    self.viewModel.effect(action: .decreaseLongBpm(currentBpm: self.viewModel.state.bpm))
+                    self.viewModel.effect(action: .setSpeed(speed: max(0.08, self.viewModel.state.speed * 0.5)))
                     restartTimer(isIncreasing: isIncreasing)
                 }
             }
     }
     
     private func stopTimer() {
-        controlViewModel.timerCancellable?.cancel()
-        controlViewModel.timerCancellable = nil
+        self.viewModel.timerCancellable?.cancel()
+        self.viewModel.timerCancellable = nil
     }
     
     // 단일탭 액션
     private func tapOnceAction(isIncreasing: Bool) {
-        self.controlViewModel.effect(action: isIncreasing ? .increaseShortBpm : .decreaseShortBpm)
+        self.viewModel.effect(action: isIncreasing ? .increaseShortBpm : .decreaseShortBpm)
         
         withAnimation {
-            controlViewModel.effect(action: .toggleActiveState(isIncreasing: isIncreasing, isActive: true))
+            self.viewModel.effect(action: .toggleActiveState(isIncreasing: isIncreasing, isActive: true))
         }
         
         // 클릭 후 다시 비활성화 색상
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
             withAnimation {
-                controlViewModel.effect(action: .toggleActiveState(isIncreasing: isIncreasing, isActive: false))
+                self.viewModel.effect(action: .toggleActiveState(isIncreasing: isIncreasing, isActive: false))
             }
         }
     }
@@ -196,7 +195,7 @@ struct MetronomeControlView: View {
     // 롱탭 액션
     private func tapTwiceAction(isIncreasing: Bool, isPressing: Bool) {
         withAnimation {
-            controlViewModel.effect(action: .toggleActiveState(isIncreasing: isIncreasing, isActive: isPressing))
+            self.viewModel.effect(action: .toggleActiveState(isIncreasing: isIncreasing, isActive: isPressing))
         }
         
         if isPressing {
@@ -209,27 +208,27 @@ struct MetronomeControlView: View {
     // 드래그 제스쳐 액션
     private func dragAction(gesture: DragGesture.Value) {
         // 현재 위치값을 기준으로 증감 측정
-        let translationDifference = gesture.translation.width - controlViewModel.state.previousTranslation
+        let translationDifference = gesture.translation.width - self.viewModel.state.previousTranslation
         
         if abs(translationDifference) > threshold {   // 음수값도 있기 때문에 절댓값 사용
             if translationDifference > 0 {
-                self.controlViewModel.effect(action: .increaseShortBpm)
-                controlViewModel.effect(action: .toggleActiveState(isIncreasing: true, isActive: true))
-                controlViewModel.effect(action: .toggleActiveState(isIncreasing: false, isActive: false))
+                self.viewModel.effect(action: .increaseShortBpm)
+                self.viewModel.effect(action: .toggleActiveState(isIncreasing: true, isActive: true))
+                self.viewModel.effect(action: .toggleActiveState(isIncreasing: false, isActive: false))
             } else if translationDifference < 0 {
-                self.controlViewModel.effect(action: .decreaseShortBpm)
-                controlViewModel.effect(action: .toggleActiveState(isIncreasing: false, isActive: true))
-                controlViewModel.effect(action: .toggleActiveState(isIncreasing: true, isActive: false))
+                self.viewModel.effect(action: .decreaseShortBpm)
+                self.viewModel.effect(action: .toggleActiveState(isIncreasing: false, isActive: true))
+                self.viewModel.effect(action: .toggleActiveState(isIncreasing: true, isActive: false))
             }
             
-            controlViewModel.effect(action: .setPreviousTranslation(position: gesture.translation.width))
+            self.viewModel.effect(action: .setPreviousTranslation(position: gesture.translation.width))
         }
     }
     
     // 드래그 제스쳐 끝났을 때
     private func dragEnded() {
-        controlViewModel.effect(action: .toggleActiveState(isIncreasing: false, isActive: false))
-        controlViewModel.effect(action: .toggleActiveState(isIncreasing: true, isActive: false))
-        controlViewModel.effect(action: .setPreviousTranslation(position: 0))
+        self.viewModel.effect(action: .toggleActiveState(isIncreasing: false, isActive: false))
+        self.viewModel.effect(action: .toggleActiveState(isIncreasing: true, isActive: false))
+        self.viewModel.effect(action: .setPreviousTranslation(position: 0))
     }
 }

--- a/Macro/Screen/MetronomeScreen/MetronomeView.swift
+++ b/Macro/Screen/MetronomeScreen/MetronomeView.swift
@@ -49,7 +49,7 @@ struct MetronomeView: View {
                 ListenSobakToggleView(isSobakOn: $isSobakOn)
                     .padding(.bottom, 16)
             }
-            MetronomeControlView(viewModel: viewModel)
+            MetronomeControlView()
         }
         // 빠르기 찾기 기능 비활성화 용도
         .contentShape(Rectangle())

--- a/Macro/Screen/MetronomeScreen/ViewModel/MetronomeControlViewModel.swift
+++ b/Macro/Screen/MetronomeScreen/ViewModel/MetronomeControlViewModel.swift
@@ -15,13 +15,15 @@ class MetronomeControlViewModel {
     private var jangdanRepository: JangdanRepository
     private var taptapUseCase: TapTapUseCase
     private var tempoUseCase: TempoUseCase
+    private var metronomeOnOffUseCase: MetronomeOnOffUseCase
     
     var timerCancellable: AnyCancellable?
     
-    init(jangdanRepository: JangdanRepository, taptapUseCase: TapTapUseCase, tempoUseCase: TempoUseCase) {
+    init(jangdanRepository: JangdanRepository, taptapUseCase: TapTapUseCase, tempoUseCase: TempoUseCase, metronomeOnOffUseCase: MetronomeOnOffUseCase) {
         self.jangdanRepository = jangdanRepository
         self.taptapUseCase = taptapUseCase
         self.tempoUseCase = tempoUseCase
+        self.metronomeOnOffUseCase = metronomeOnOffUseCase
         
         self.timerCancellable = nil
         
@@ -36,6 +38,12 @@ class MetronomeControlViewModel {
             self._state.bpm = jangdan.bpm
         }
         .store(in: &self.cancelBag)
+        
+        self.metronomeOnOffUseCase.isPlayingPublisher.sink { [weak self] isPlaying in
+            guard let self else { return }
+            self._state.isPlaying = isPlaying
+        }
+        .store(in: &self.cancelBag)
     }
     
     private var _state: State = .init()
@@ -44,6 +52,7 @@ class MetronomeControlViewModel {
     }
     
     struct State {
+        var isPlaying: Bool = false
         var isMinusActive: Bool = false
         var isPlusActive: Bool = false
         var previousTranslation: CGFloat = .zero

--- a/Macro/Screen/MetronomeScreen/ViewModel/MetronomeControlViewModel.swift
+++ b/Macro/Screen/MetronomeScreen/ViewModel/MetronomeControlViewModel.swift
@@ -64,6 +64,7 @@ class MetronomeControlViewModel {
 
 extension MetronomeControlViewModel {
     enum Action {
+        case changeIsPlaying
         case decreaseShortBpm
         case decreaseLongBpm(currentBpm: Int)
         case increaseShortBpm
@@ -77,6 +78,12 @@ extension MetronomeControlViewModel {
     
     func effect(action: Action) {
         switch action {
+        case .changeIsPlaying:
+            if self._state.isPlaying {
+                self.metronomeOnOffUseCase.stop()
+            } else {
+                self.metronomeOnOffUseCase.play()
+            }
         case .decreaseShortBpm:
             self.tempoUseCase.updateTempo(newBpm: self._state.bpm - 1)
             self.taptapUseCase.finishTapping()

--- a/Macro/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
+++ b/Macro/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
@@ -47,6 +47,12 @@ class MetronomeViewModel {
             self._state.isPlaying = isPlaying
         }
         .store(in: &self.cancelBag)
+        
+        self.metronomeOnOffUseCase.tickPublisher.sink { [weak self] _ in
+            guard let self else { return }
+            self.updateStatePerBak()
+        }
+        .store(in: &self.cancelBag)
     }
     
     private var _state: State = .init()
@@ -96,11 +102,9 @@ extension MetronomeViewModel {
         case .changeIsPlaying:
             self.initialDaeSoBakIndex()
             if self._state.isPlaying {
-                self.metronomeOnOffUseCase.play {
-                    self.updateStatePerBak()
-                }
-            } else {
                 self.metronomeOnOffUseCase.stop()
+            } else {
+                self.metronomeOnOffUseCase.play()
             }
             
         case let .changeAccent(row, daebak, sobak, newAccent):

--- a/Macro/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
+++ b/Macro/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
@@ -95,7 +95,6 @@ extension MetronomeViewModel {
             self.metronomeOnOffUseCase.changeSobak()
         case .changeIsPlaying:
             self.initialDaeSoBakIndex()
-//            self._state.isPlaying.toggle()
             if self._state.isPlaying {
                 self.metronomeOnOffUseCase.play {
                     self.updateStatePerBak()
@@ -107,7 +106,6 @@ extension MetronomeViewModel {
         case let .changeAccent(row, daebak, sobak, newAccent):
             self.accentUseCase.moveNextAccent(rowIndex: row, daebakIndex: daebak, sobakIndex: sobak, to: newAccent)
         case .stopMetronome: // 시트 변경 시 소리 중지를 위해 사용함
-//            self._state.isPlaying = false
             if self._state.isSobakOn {
                 self._state.isSobakOn = false
                 self.metronomeOnOffUseCase.changeSobak()

--- a/Macro/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
+++ b/Macro/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
@@ -95,7 +95,7 @@ extension MetronomeViewModel {
             self.metronomeOnOffUseCase.changeSobak()
         case .changeIsPlaying:
             self.initialDaeSoBakIndex()
-            self._state.isPlaying.toggle()
+//            self._state.isPlaying.toggle()
             if self._state.isPlaying {
                 self.metronomeOnOffUseCase.play {
                     self.updateStatePerBak()
@@ -107,7 +107,7 @@ extension MetronomeViewModel {
         case let .changeAccent(row, daebak, sobak, newAccent):
             self.accentUseCase.moveNextAccent(rowIndex: row, daebakIndex: daebak, sobakIndex: sobak, to: newAccent)
         case .stopMetronome: // 시트 변경 시 소리 중지를 위해 사용함
-            self._state.isPlaying = false
+//            self._state.isPlaying = false
             if self._state.isSobakOn {
                 self._state.isSobakOn = false
                 self.metronomeOnOffUseCase.changeSobak()

--- a/Macro/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
+++ b/Macro/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
@@ -44,6 +44,7 @@ class MetronomeViewModel {
         
         self.metronomeOnOffUseCase.isPlayingPublisher.sink { [weak self] isPlaying in
             guard let self else { return }
+            self.initialDaeSoBakIndex()
             self._state.isPlaying = isPlaying
         }
         .store(in: &self.cancelBag)
@@ -100,7 +101,6 @@ extension MetronomeViewModel {
             self._state.isSobakOn.toggle()
             self.metronomeOnOffUseCase.changeSobak()
         case .changeIsPlaying:
-            self.initialDaeSoBakIndex()
             if self._state.isPlaying {
                 self.metronomeOnOffUseCase.stop()
             } else {

--- a/Macro/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
+++ b/Macro/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
@@ -41,6 +41,12 @@ class MetronomeViewModel {
             self._state.isTapping = isTapping
         }
         .store(in: &self.cancelBag)
+        
+        self.metronomeOnOffUseCase.isPlayingPublisher.sink { [weak self] isPlaying in
+            guard let self else { return }
+            self._state.isPlaying = isPlaying
+        }
+        .store(in: &self.cancelBag)
     }
     
     private var _state: State = .init()

--- a/Macro/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
+++ b/Macro/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
@@ -78,7 +78,6 @@ extension MetronomeViewModel {
     enum Action: Equatable {
         case selectJangdan(selectedJangdanName: String)
         case changeSobakOnOff
-        case changeIsPlaying
         case changeAccent(row: Int, daebak: Int, sobak: Int, newAccent: Accent)
         case stopMetronome
         case estimateBpm
@@ -100,12 +99,6 @@ extension MetronomeViewModel {
         case .changeSobakOnOff:
             self._state.isSobakOn.toggle()
             self.metronomeOnOffUseCase.changeSobak()
-        case .changeIsPlaying:
-            if self._state.isPlaying {
-                self.metronomeOnOffUseCase.stop()
-            } else {
-                self.metronomeOnOffUseCase.play()
-            }
             
         case let .changeAccent(row, daebak, sobak, newAccent):
             self.accentUseCase.moveNextAccent(rowIndex: row, daebakIndex: daebak, sobakIndex: sobak, to: newAccent)

--- a/Macro/System/DIContainer.swift
+++ b/Macro/System/DIContainer.swift
@@ -24,7 +24,7 @@ class DIContainer {
         self._metronomeViewModel = MetronomeViewModel(templateUseCase: self._templateUseCase, metronomeOnOffUseCase: self._metronomeOnOffUseCase, tempoUseCase: self._tempoUseCase, accentUseCase: self._accentUseCase, taptapUseCase: self._tapTapUseCase)
         
         self._controlViewModel =
-        MetronomeControlViewModel(jangdanRepository: self._jangdanDataSource, taptapUseCase: self._tapTapUseCase, tempoUseCase: self._tempoUseCase)
+        MetronomeControlViewModel(jangdanRepository: self._jangdanDataSource, taptapUseCase: self._tapTapUseCase, tempoUseCase: self._tempoUseCase, metronomeOnOffUseCase: self._metronomeOnOffUseCase)
         
         self._homeViewModel = HomeViewModel(metronomeOnOffUseCase: self._metronomeOnOffUseCase)
         self._customJangdanListViewModel = CustomJangdanListViewModel(templateUseCase: self._templateUseCase)


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
Metronome 재생 화면을 벗어나더라도 재생 여부가 초기화되지 않아 다시 Metronome 화면 진입시 재생중인 화면으로 보이는 이슈

isPlaying 값을 MetronomeOnOffUseCase 에서 Publish 해서 필요로 하는 ViewModel들이 구독하는 형태로 변경했습니다.

<!-- Close #311  -->

## 작업 내용
### 1. isPlayingPublisher
- MetronomeOnOffUseCase에 Publisher 추가
- MetronomeOnOffImplement에 Subject 추가
- play / stop 시 isPlaying값 publish 로직 추가

### 2. MetronomeViewModel에서 재생여부 구독
- 구독하는 곳에서 내부 상태값 변경하는 로직 추가
- 내부에서 isPlaying 자체적으로 변경하는 로직 제거

### 3. MetronomeControlViewModel에서 재생여부 구독
- MetronomeControlView에서 MetronomeViewMoel의 isPlaying 변수를 사용하고 있었음
- MetronomeControlViewModel에서 OnOffUseCase를 직접 참조함으로써 MetronomeViewModel에 대한 의존성 제거

### 4. play / stop 로직 MetronomeControlViewModel로 이동
- MetronomeViewModel의 play/stop 로직을 실제 버튼이 있는 MetronomeControlViewModel로 이동
- isPlaying 값에 따라 OnOffUseCase의 play / stop 메서드 호출

### 5. tickPublisher
- MetronomeOnOffUseCase의 play 메서드에서 handler를 받기 때문에 MetronomeViewModel에서 분리할 수 없는 이슈 발생
- 따라서 MetronomeOnOffUseCase에서 타이머의 tick마다 이벤트를 publish 하는 방식으로 변경
- MetronomeViewModel에서는 해당 이벤트를 받아 View를 갱신하도록 변경
- play 메서드에서 Handler를 받을 필요가 없어져서 MetronomeControlView에서 재생로직 담당할 수 있게 됨

### 6. MetronomeControlView의 ViewModel 단일화
- MetronomeControlViewModel에서 재생로직을 담당함
- 따라서 MetronomeControlView가 MetronomeViewModel을 참조할 필요가 없어짐

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
