### PR TITLE
[Chore] #319 암호화 알고리즘 사용 여부를 설정합니다

### DIFF
--- a/Macro.xcodeproj/project.pbxproj
+++ b/Macro.xcodeproj/project.pbxproj
@@ -882,7 +882,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = Krabs.Macro;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -924,7 +924,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = Krabs.Macro;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Macro/Info.plist
+++ b/Macro/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Medium.otf</string>


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
매번 앱을 빌드해 올릴때마다 수출 규정 관리 관련 문서 누락 이슈가 발생하는 바람에
매번 커넥트에 접속해 해결해줘야 하는 문제가 있어서
프로젝트에서 설정해줌으로써 더이상 해당 이슈가 발생하지 않도록 합니다.

<!-- Close #319  -->

## 작업 내용
### 1. info.plist 에 관련값 추가
- App Uses Non-Exempt Encryption - NO

### 2. 버전 업데이트 - 2.2.1
- 기존 버전으로는 Xcode Cloud에서 아카이빙할수 없어서 버전 넘버를 올립니다

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
