### PR TITLE
[Refactor] #322 private 변수 가독성 향상

### DIFF
--- a/Macro/Screen/BuiltInJangdanScreen/ViewModel/BuiltInJangdanPracticeViewModel.swift
+++ b/Macro/Screen/BuiltInJangdanScreen/ViewModel/BuiltInJangdanPracticeViewModel.swift
@@ -21,15 +21,12 @@ class BuiltInJangdanPracticeViewModel {
         
         self.templateUseCase.currentJangdanTypePublisher.sink { [weak self] jangdanType in
             guard let self else { return }
-            self._state.currentJangdanType = jangdanType
+            self.state.currentJangdanType = jangdanType
         }
         .store(in: &cancelbag)
     }
     
-    private var _state: State = .init()
-    var state: State {
-        return _state
-    }
+    private(set) var state: State = .init()
     
     struct State {
         var currentJangdanName: String?

--- a/Macro/Screen/CustomJangdanListScreen/ViewModel/CustomJangdanCreateViewModel.swift
+++ b/Macro/Screen/CustomJangdanListScreen/ViewModel/CustomJangdanCreateViewModel.swift
@@ -21,16 +21,13 @@ class CustomJangdanCreateViewModel {
         
         self.templateUseCase.currentJangdanTypePublisher.sink { [weak self] jangdanType in
             guard let self else { return }
-            self._state.currentJangdanType = jangdanType
+            self.state.currentJangdanType = jangdanType
         }
         .store(in: &cancelbag)
         
     }
     
-    private var _state: State = .init()
-    var state: State {
-        return _state
-    }
+    private(set) var state: State = .init()
     
     struct State {
         var currentJangdanType: Jangdan?

--- a/Macro/Screen/CustomJangdanListScreen/ViewModel/CustomJangdanListViewModel.swift
+++ b/Macro/Screen/CustomJangdanListScreen/ViewModel/CustomJangdanListViewModel.swift
@@ -21,8 +21,7 @@ class CustomJangdanListViewModel {
         var customJangdanList: [JangdanSimpleType] = []
     }
     
-    private var _state: State = .init()
-    var state: State { _state }
+    private(set) var state: State = .init()
 }
 
 extension CustomJangdanListViewModel {
@@ -34,7 +33,7 @@ extension CustomJangdanListViewModel {
     func effect(action: Action) {
         switch action {
         case .fetchCustomJangdanData:
-            self._state.customJangdanList = templateUseCase.allCustomJangdanTemplate.map { jangdanEntity in
+            self.state.customJangdanList = templateUseCase.allCustomJangdanTemplate.map { jangdanEntity in
                 return (jangdanEntity.jangdanType, jangdanEntity.name, jangdanEntity.createdAt ?? .now)
             }.sorted {
                 $0.lastUpdate > $1.lastUpdate

--- a/Macro/Screen/CustomJangdanListScreen/ViewModel/CustomJangdanPracticeViewModel.swift
+++ b/Macro/Screen/CustomJangdanListScreen/ViewModel/CustomJangdanPracticeViewModel.swift
@@ -21,15 +21,12 @@ class CustomJangdanPracticeViewModel {
         
         self.templateUseCase.currentJangdanTypePublisher.sink { [weak self] jangdanType in
             guard let self else { return }
-            self._state.currentJangdanType = jangdanType
+            self.state.currentJangdanType = jangdanType
         }
         .store(in: &cancelbag)
     }
     
-    private var _state: State = .init()
-    var state: State {
-        return _state
-    }
+    private(set) var state: State = .init()
     
     struct State {
         var currentJangdanType: Jangdan?

--- a/Macro/Screen/MetronomeScreen/ViewModel/MetronomeControlViewModel.swift
+++ b/Macro/Screen/MetronomeScreen/ViewModel/MetronomeControlViewModel.swift
@@ -29,27 +29,24 @@ class MetronomeControlViewModel {
         
         self.taptapUseCase.isTappingPublisher.sink { [weak self] isTapping in
             guard let self else { return }
-            self._state.isTapping = isTapping
+            self.state.isTapping = isTapping
         }
         .store(in: &self.cancelBag)
         
         self.jangdanRepository.jangdanPublisher.sink { [weak self] jangdan in
             guard let self else { return }
-            self._state.bpm = jangdan.bpm
+            self.state.bpm = jangdan.bpm
         }
         .store(in: &self.cancelBag)
         
         self.metronomeOnOffUseCase.isPlayingPublisher.sink { [weak self] isPlaying in
             guard let self else { return }
-            self._state.isPlaying = isPlaying
+            self.state.isPlaying = isPlaying
         }
         .store(in: &self.cancelBag)
     }
     
-    private var _state: State = .init()
-    var state: State {
-        return _state
-    }
+    private(set) var state: State = .init()
     
     struct State {
         var isPlaying: Bool = false
@@ -79,13 +76,13 @@ extension MetronomeControlViewModel {
     func effect(action: Action) {
         switch action {
         case .changeIsPlaying:
-            if self._state.isPlaying {
+            if self.state.isPlaying {
                 self.metronomeOnOffUseCase.stop()
             } else {
                 self.metronomeOnOffUseCase.play()
             }
         case .decreaseShortBpm:
-            self.tempoUseCase.updateTempo(newBpm: self._state.bpm - 1)
+            self.tempoUseCase.updateTempo(newBpm: self.state.bpm - 1)
             self.taptapUseCase.finishTapping()
         case let .decreaseLongBpm(currentBpm):
             let remainder = currentBpm % 10
@@ -93,7 +90,7 @@ extension MetronomeControlViewModel {
             self.tempoUseCase.updateTempo(newBpm: roundedBpm - 10)
             self.taptapUseCase.finishTapping()
         case .increaseShortBpm:
-            self.tempoUseCase.updateTempo(newBpm: self._state.bpm + 1)
+            self.tempoUseCase.updateTempo(newBpm: self.state.bpm + 1)
             self.taptapUseCase.finishTapping()
         case let .increaseLongBpm(currentBpm):
             let roundedBpm = currentBpm - (currentBpm % 10)
@@ -105,14 +102,14 @@ extension MetronomeControlViewModel {
             self.taptapUseCase.tap()
         case let .toggleActiveState(isIncreasing, isActive):
             if isIncreasing {
-                self._state.isPlusActive = isActive
+                self.state.isPlusActive = isActive
             } else {
-                self._state.isMinusActive = isActive
+                self.state.isMinusActive = isActive
             }
         case let .setPreviousTranslation(position):
-            self._state.previousTranslation = position
+            self.state.previousTranslation = position
         case let .setSpeed(speed):
-            self._state.speed = speed
+            self.state.speed = speed
         }
     }
 }

--- a/Macro/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
+++ b/Macro/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
@@ -26,32 +26,32 @@ class MetronomeViewModel {
         
         self.templateUseCase.currentJangdanTypePublisher.sink { [weak self] jangdanType in
             guard let self else { return }
-            self._state.currentJangdanType = jangdanType
+            self.state.currentJangdanType = jangdanType
         }
         .store(in: &self.cancelBag)
         
         self.accentUseCase.accentListPublisher.sink { [weak self] accentList in
             guard let self else { return }
-            self._state.jangdanAccent = accentList
+            self.state.jangdanAccent = accentList
         }
         .store(in: &self.cancelBag)
         
         self.taptapUseCase.isTappingPublisher.sink { [weak self] isTapping in
             guard let self else { return }
-            self._state.isTapping = isTapping
+            self.state.isTapping = isTapping
         }
         .store(in: &self.cancelBag)
         
         self.metronomeOnOffUseCase.isPlayingPublisher.sink { [weak self] isPlaying in
             guard let self else { return }
             self.initialDaeSoBakIndex()
-            self._state.isPlaying = isPlaying
+            self.state.isPlaying = isPlaying
         }
         .store(in: &self.cancelBag)
         
         self.metronomeOnOffUseCase.isSobakOnPublisher.sink { [weak self] isSobakOn in
             guard let self else { return }
-            self._state.isSobakOn = isSobakOn
+            self.state.isSobakOn = isSobakOn
         }
         .store(in: &self.cancelBag)
         
@@ -62,10 +62,7 @@ class MetronomeViewModel {
         .store(in: &self.cancelBag)
     }
     
-    private var _state: State = .init()
-    var state: State {
-        return _state
-    }
+    private(set) var state: State = .init()
     
     struct State {
         var currentJangdanName: String?
@@ -97,11 +94,11 @@ extension MetronomeViewModel {
         
         switch action {
         case let .selectJangdan(jangdanName):
-            self._state.currentJangdanName = jangdanName
+            self.state.currentJangdanName = jangdanName
             self.templateUseCase.setJangdan(jangdanName: jangdanName)
             self.initialDaeSoBakIndex()
             self.taptapUseCase.finishTapping()
-            if self._state.isSobakOn {
+            if self.state.isSobakOn {
                 self.metronomeOnOffUseCase.changeSobak()
             }
         case .changeSobakOnOff:
@@ -110,7 +107,7 @@ extension MetronomeViewModel {
         case let .changeAccent(row, daebak, sobak, newAccent):
             self.accentUseCase.moveNextAccent(rowIndex: row, daebakIndex: daebak, sobakIndex: sobak, to: newAccent)
         case .stopMetronome: // 시트 변경 시 소리 중지를 위해 사용함
-            if self._state.isSobakOn {
+            if self.state.isSobakOn {
                 self.metronomeOnOffUseCase.changeSobak()
             }
             self.metronomeOnOffUseCase.stop()
@@ -122,16 +119,16 @@ extension MetronomeViewModel {
     }
     
     private func updateStatePerBak() {
-        var nextSobak: Int = self._state.currentSobak
-        var nextDaebak: Int = self._state.currentDaebak
-        var nextRow: Int = self._state.currentRow
+        var nextSobak: Int = self.state.currentSobak
+        var nextDaebak: Int = self.state.currentDaebak
+        var nextRow: Int = self.state.currentRow
         
         nextSobak += 1
-        if nextSobak == self._state.jangdanAccent[nextRow][nextDaebak].count {
+        if nextSobak == self.state.jangdanAccent[nextRow][nextDaebak].count {
             nextDaebak += 1
-            if nextDaebak == self._state.jangdanAccent[nextRow].count {
+            if nextDaebak == self.state.jangdanAccent[nextRow].count {
                 nextRow += 1
-                if nextRow == self._state.jangdanAccent.count {
+                if nextRow == self.state.jangdanAccent.count {
                     nextRow = 0
                 }
                 nextDaebak = 0
@@ -139,14 +136,14 @@ extension MetronomeViewModel {
             nextSobak = 0
         }
         
-        self._state.currentSobak = nextSobak
-        self._state.currentDaebak = nextDaebak
-        self._state.currentRow = nextRow
+        self.state.currentSobak = nextSobak
+        self.state.currentDaebak = nextDaebak
+        self.state.currentRow = nextRow
     }
     
     private func initialDaeSoBakIndex() {
-        self._state.currentRow = self._state.jangdanAccent.count - 1
-        self._state.currentDaebak = self._state.jangdanAccent[self._state.currentRow].count - 1
-        self._state.currentSobak = self._state.jangdanAccent[self._state.currentRow][self._state.currentDaebak].count - 1
+        self.state.currentRow = self.state.jangdanAccent.count - 1
+        self.state.currentDaebak = self.state.jangdanAccent[self.state.currentRow].count - 1
+        self.state.currentSobak = self.state.jangdanAccent[self.state.currentRow][self.state.currentDaebak].count - 1
     }
 }

--- a/Macro/System/AppState.swift
+++ b/Macro/System/AppState.swift
@@ -12,47 +12,41 @@ class AppState {
     
     init() {
 #if DEBUG
-        self._didLaunchedBefore = false
+        self.didLaunchedBefore = false
 #else
-        self._didLaunchedBefore = UserDefaults.standard.bool(forKey: "didLaunchedBefore")
+        self.didLaunchedBefore = UserDefaults.standard.bool(forKey: "didLaunchedBefore")
 #endif
         
         let instrument = UserDefaults.standard.string(forKey: "selectedInstrument") ?? "장구"
-        self._selectedInstrument = Instrument(rawValue: instrument) ?? .장구
+        self.selectedInstrument = Instrument(rawValue: instrument) ?? .장구
         
-        self._isBeepSound = UserDefaults.standard.bool(forKey: "isBeepSound")
+        self.isBeepSound = UserDefaults.standard.bool(forKey: "isBeepSound")
     }
     
     // 최초실행여부
-    private var _didLaunchedBefore: Bool
+    private(set) var didLaunchedBefore: Bool
     
     // 선택된 악기
-    private var _selectedInstrument: Instrument
+    private(set) var selectedInstrument: Instrument
     
     // 비프음 여부
-    private var _isBeepSound: Bool
+    private(set) var isBeepSound: Bool
     
 }
 
 extension AppState {
-    var didLaunchedBefore: Bool { self._didLaunchedBefore }
-    
-    var selectedInstrument: Instrument { self._selectedInstrument }
-    
-    var isBeepSound: Bool { self._isBeepSound }
-    
     func appLaunched() {
-        self._didLaunchedBefore = true
+        self.didLaunchedBefore = true
         UserDefaults.standard.set(true, forKey: "didLaunchedBefore")
     }
     
     func setInstrument(_ instrument: Instrument) {
-        self._selectedInstrument = instrument
+        self.selectedInstrument = instrument
         UserDefaults.standard.set(instrument.rawValue, forKey: "selectedInstrument")
     }
     
     func toggleBeepSound() {
-        self._isBeepSound.toggle()
-        UserDefaults.standard.set(self._isBeepSound, forKey: "isBeepSound")
+        self.isBeepSound.toggle()
+        UserDefaults.standard.set(self.isBeepSound, forKey: "isBeepSound")
     }
 }

--- a/Macro/System/DIContainer.swift
+++ b/Macro/System/DIContainer.swift
@@ -11,87 +11,60 @@ class DIContainer {
     static let shared: DIContainer = DIContainer()
     
     private init() {
-        self._appState = .init()
-        self._jangdanDataSource = .init(appState: self._appState)!
-        self._soundManager = .init(appState: self._appState)!
+        self.appState = .init()
+        self.jangdanDataSource = .init(appState: self.appState)!
+        self.soundManager = .init(appState: self.appState)!
         
-        self._templateUseCase = TemplateImplement(jangdanRepository: self._jangdanDataSource, appState: self._appState)
-        self._tempoUseCase = TempoImplement(jangdanRepository: self._jangdanDataSource)
-        self._metronomeOnOffUseCase = MetronomeOnOffImplement(jangdanRepository: self._jangdanDataSource, soundManager: _soundManager)
-        self._accentUseCase = AccentImplement(jangdanRepository: self._jangdanDataSource)
-        self._tapTapUseCase = TapTapImplement(tempoUseCase: self._tempoUseCase)
+        self.templateUseCase = TemplateImplement(jangdanRepository: self.jangdanDataSource, appState: self.appState)
+        self.tempoUseCase = TempoImplement(jangdanRepository: self.jangdanDataSource)
+        self.metronomeOnOffUseCase = MetronomeOnOffImplement(jangdanRepository: self.jangdanDataSource, soundManager: soundManager)
+        self.accentUseCase = AccentImplement(jangdanRepository: self.jangdanDataSource)
+        self.tapTapUseCase = TapTapImplement(tempoUseCase: self.tempoUseCase)
         
-        self._metronomeViewModel = MetronomeViewModel(templateUseCase: self._templateUseCase, metronomeOnOffUseCase: self._metronomeOnOffUseCase, tempoUseCase: self._tempoUseCase, accentUseCase: self._accentUseCase, taptapUseCase: self._tapTapUseCase)
+        self.metronomeViewModel = MetronomeViewModel(templateUseCase: self.templateUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase, tempoUseCase: self.tempoUseCase, accentUseCase: self.accentUseCase, taptapUseCase: self.tapTapUseCase)
         
-        self._controlViewModel =
-        MetronomeControlViewModel(jangdanRepository: self._jangdanDataSource, taptapUseCase: self._tapTapUseCase, tempoUseCase: self._tempoUseCase, metronomeOnOffUseCase: self._metronomeOnOffUseCase)
+        self.controlViewModel =
+        MetronomeControlViewModel(jangdanRepository: self.jangdanDataSource, taptapUseCase: self.tapTapUseCase, tempoUseCase: self.tempoUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase)
         
-        self._homeViewModel = HomeViewModel(metronomeOnOffUseCase: self._metronomeOnOffUseCase)
-        self._customJangdanListViewModel = CustomJangdanListViewModel(templateUseCase: self._templateUseCase)
-        self._builtInJangdanPracticeViewModel = BuiltInJangdanPracticeViewModel(templateUseCase: self._templateUseCase, metronomeOnOffUseCase: self._metronomeOnOffUseCase)
-        self._customJangdanPracticeViewModel = CustomJangdanPracticeViewModel(templateUseCase: self._templateUseCase, metronomeOnOffUseCase: self._metronomeOnOffUseCase)
-        self._customJangdanCreateViewModel = CustomJangdanCreateViewModel(templateUseCase: self._templateUseCase, metronomeOnOffUseCase: self._metronomeOnOffUseCase)
+        self.homeViewModel = HomeViewModel(metronomeOnOffUseCase: self.metronomeOnOffUseCase)
+        self.customJangdanListViewModel = CustomJangdanListViewModel(templateUseCase: self.templateUseCase)
+        self.builtInJangdanPracticeViewModel = BuiltInJangdanPracticeViewModel(templateUseCase: self.templateUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase)
+        self.customJangdanPracticeViewModel = CustomJangdanPracticeViewModel(templateUseCase: self.templateUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase)
+        self.customJangdanCreateViewModel = CustomJangdanCreateViewModel(templateUseCase: self.templateUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase)
         
-        self._router = .init()
+        self.router = .init()
     }
     
     // ViewModel
-    private var _metronomeViewModel: MetronomeViewModel
-    var metronomeViewModel: MetronomeViewModel {
-        self._metronomeViewModel
-    }
+    private(set) var metronomeViewModel: MetronomeViewModel
     
-    // controllerViewModel
-    private var _controlViewModel: MetronomeControlViewModel
-    var controlViewModel: MetronomeControlViewModel {
-        self._controlViewModel
-    }
+    private(set) var controlViewModel: MetronomeControlViewModel
     
-    private var _homeViewModel: HomeViewModel
-    var homeViewModel: HomeViewModel {
-        self._homeViewModel
-    }
+    private(set) var homeViewModel: HomeViewModel
     
-    private var _customJangdanListViewModel: CustomJangdanListViewModel
-    var customJangdanListViewModel: CustomJangdanListViewModel {
-        self._customJangdanListViewModel
-    }
+    private(set) var customJangdanListViewModel: CustomJangdanListViewModel
     
-    private var _builtInJangdanPracticeViewModel: BuiltInJangdanPracticeViewModel
-    var builtInJangdanPracticeViewModel: BuiltInJangdanPracticeViewModel {
-        self._builtInJangdanPracticeViewModel
-    }
+    private(set) var builtInJangdanPracticeViewModel: BuiltInJangdanPracticeViewModel
     
-    private var _customJangdanPracticeViewModel: CustomJangdanPracticeViewModel
-    var customJangdanPracticeViewModel: CustomJangdanPracticeViewModel {
-        self._customJangdanPracticeViewModel
-    }
+    private(set) var customJangdanPracticeViewModel: CustomJangdanPracticeViewModel
     
-    private var _customJangdanCreateViewModel: CustomJangdanCreateViewModel
-    var customJangdanCreateViewModel: CustomJangdanCreateViewModel {
-        self._customJangdanCreateViewModel
-    }
+    private(set) var customJangdanCreateViewModel: CustomJangdanCreateViewModel
     
     // UseCase Implements
-    private var _templateUseCase: TemplateImplement
-    private var _tempoUseCase: TempoImplement
-    private var _metronomeOnOffUseCase: MetronomeOnOffImplement
-    private var _accentUseCase: AccentImplement
-    private var _tapTapUseCase: TapTapImplement
+    private var templateUseCase: TemplateImplement
+    private var tempoUseCase: TempoImplement
+    private var metronomeOnOffUseCase: MetronomeOnOffImplement
+    private var accentUseCase: AccentImplement
+    private var tapTapUseCase: TapTapImplement
     
-    private var _jangdanDataSource: JangdanDataManager
-    private var _soundManager: SoundManager
+    // Service
+    private var jangdanDataSource: JangdanDataManager
+    private var soundManager: SoundManager
     
-    //router
-    private var _router: Router
-    var router: Router {
-        self._router
-    }
+    // Router
+    private(set) var router: Router
     
-    //appState
-    private var _appState: AppState
-    var appState: AppState {
-        self._appState
-    }
+    // AppState
+    private(set) var appState: AppState
     
 }


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
외부에서 접근하지 못하도록 하는 기능만을 목적으로 하는
```
private _variable
```
변수들을
```
private(set) variable
```
로 변경합니다.

코드량이 줄어들고 이해하기 편해질거같아요 (아닌가?)

<!-- Close #322  -->

## 작업 내용
### 1. DIContainer
- 주입되는 객체들을 변경했습니다
- UseCase
- Service
- ViewModel

### 2. AppState
- 내부 변수들을 변경했습니다.
- 지금은 메서드로 내부 값을 변경하고 있어서 단순히 형식만 변경했는데
- 외부에서 메서드 대신 변수 자체에 get / set 로직으로 접근하게 변경하는 방식이 나을지 고민했습니다
- 근데 외부(ViewModel)에서 변수를 직접 변경하는것보다 메서드 호출하는게 지금 무슨 행위를 하는지 더 명확하게 표시된다고 생각해서 바꾸진 않았읍니다.

### 3. ViewModels
- 내부의 state 객체를 변경했습니다.

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
처음엔 왜 이생각 못했지
저는 바보입니다