### PR TITLE
[Fix] #358 블루투스 연결 시 소리 재생이 안되는 문제 해결

### DIFF
--- a/Macro/Service/SoundManager.swift
+++ b/Macro/Service/SoundManager.swift
@@ -24,7 +24,7 @@ class SoundManager {
         
         // AudioSession 설정
         do {
-            try self.audioSession.setCategory(.playback, options: [.mixWithOthers, .allowBluetoothA2DP])
+            try self.audioSession.setCategory(.playAndRecord, options: [.mixWithOthers, .defaultToSpeaker, .allowBluetoothA2DP])
             try self.audioSession.setActive(true)
         } catch {
             print("SoundManager: 오디오 세션 설정 중 에러 발생 - \(error)")

--- a/Macro/Service/SoundManager.swift
+++ b/Macro/Service/SoundManager.swift
@@ -24,7 +24,7 @@ class SoundManager {
         
         // AudioSession 설정
         do {
-            try self.audioSession.setCategory(.playback, options: [.mixWithOthers])
+            try self.audioSession.setCategory(.playback, options: [.mixWithOthers, .allowBluetoothA2DP])
             try self.audioSession.setActive(true)
         } catch {
             print("SoundManager: 오디오 세션 설정 중 에러 발생 - \(error)")


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
블루투스 연결 시 소리 재생이 안되는 문제 해결
<!-- Close #358  -->

## 작업 내용
### 1. AudioSession 설정 시 블루투스 옵션 추가
- 블루투스 기기 연결 시 사운드 재생을 담당해주는 옵션인 allowBluetoothA2DP 옵션 추가해주었습니다.
- 블루투스가 연결되어 있지 않을 시 스피커로 재생되도록 .defaultToSpeaker 옵션 추가해주었습니다.(해당 옵션 없이 위 옵션만 있는 경우 블루투스 연결 시 소리가 제대로 나지 않더라구요.)
### 2. AudioSession의 Category를 .playback -> .playAndRecord로 변경
- AVAudioEngine은 오디오 신호를 처리하기 위해 오디오 노드의 그래프를 구성하는 객체로 AVAudioEngine은 기본적으로 입력을 사용하지 않더라도 내부적으로 입력 오디오를 처리할 수 있는 상태를 유지하기 위해 입력 노드(inputNode)를 활성화시킵니다. 
- 기존에 AVAudioEngine, .playback의 조합은 문제가 없었지만, .allowBluetoothA2DP가 활성화되면, iOS는 Bluetooth 장치를 출력 전용으로 활성화 시키기 때문에, AVAudioEngine은 내부적으로 입력 노드를 초기화하려고 시도하지만 .allowBluetoothA2DP 옵션이 활성화된 상태에서는 입력 노드를 사용할 수 없게 되면서 init()에서 오류가 발생하는 문제가 있었습니다.
- .allowBluetoothA2DP 옵션이 없을 때는 AVAudioEngine이 입력 노드와 관련된 작업을 시도하지 않기 때문에 시스템 충돌이 발생하지 않으나 .allowBluetoothA2DP 옵션이 입력 노드 관련 체크를 발생시키면서 충돌이 발생한 것으로 보임
- 따라서 AVAudioEngine이.allowBluetoothA2DP를 통해서 입력 노드 관련 작업을 시도할 때 playAndRecord을 통해서 입력, 출력이 모두 가능하다고 체크되도록 수정이 필요하였음.
- 다른 처리 방식으로는 저희 앱은 사운드 입력을 사용하지 않기 때문에 AVAudioEngine에서 입력모드를 사용하지 않도록 코드를 통해 강제로 false 처리하는 방법이 있지만, 사운드 서비스를 강제하기 보다 옵션을 바꾸는 것이 나을 것 같아 해당 방식으로 처리하게 되었습니다.

## 비고 <!-- (Optional) -->
- 블루투스와 관련된 옵션으로는 allowBluetooth, allowBluetoothA2DP 두가지 옵션이 있습니다. 
- allowBluetooth 옵션의 경우 음질은 떨어지지만 마이크 입력을 같이 사용할 수 있도록 지원하고, allowBluetoothA2DP의 경우 마이크 입력을 지원하지 않지만 고음질의 음원을 지원합니다. 저희는 마이크를 사용하지 않고, 소리 출력이 우선이기 때문에 굳이 사용하지 않는 옵션을 제외한 allowBluetoothA2DP 옵션만 추가하였습니다.

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
해당 건은 제가 가진 여건 상 테스트가 불가능하여, merge 이후 testflight를 통해서 테스트 환경이 있는 헤이즐에게 확인을 받고자 합니다. 