### PR TITLE
[Fix] #371 전화 수신, 발신 시 소리 재생 오류 해결

### DIFF
--- a/Macro/Domain/UseCase/Interface/PlaySoundInterface.swift
+++ b/Macro/Domain/UseCase/Interface/PlaySoundInterface.swift
@@ -10,6 +10,7 @@ import Combine
 // 소리내는 UseCase용
 protocol PlaySoundInterface {
     var callInterruptPublisher: AnyPublisher<Bool, Never> { get }
+    func audioEngineStart()
     func beep(_ accent: Accent)
     func setSoundType()
 }

--- a/Macro/Domain/UseCase/Interface/PlaySoundInterface.swift
+++ b/Macro/Domain/UseCase/Interface/PlaySoundInterface.swift
@@ -5,8 +5,11 @@
 //  Created by Yunki on 10/1/24.
 //
 
+import Combine
+
 // 소리내는 UseCase용
 protocol PlaySoundInterface {
+    var callInterruptPublisher: AnyPublisher<Bool, Never> { get }
     func beep(_ accent: Accent)
     func setSoundType()
 }

--- a/Macro/Domain/UseCase/MetronomeOnOffImplement.swift
+++ b/Macro/Domain/UseCase/MetronomeOnOffImplement.swift
@@ -90,6 +90,8 @@ extension MetronomeOnOffImplement: MetronomeOnOffUseCase {
     }
     
     func play() {
+        // AudioEngine start()
+        self.soundManager.audioEngineStart()
         // 데이터 갱신
         self.currentBeatIndex = 0
         UIApplication.shared.isIdleTimerDisabled = true

--- a/Macro/Domain/UseCase/MetronomeOnOffImplement.swift
+++ b/Macro/Domain/UseCase/MetronomeOnOffImplement.swift
@@ -61,6 +61,12 @@ class MetronomeOnOffImplement {
             self.timer?.schedule(deadline: .now() + nextStartTime, repeating: self.interval, leeway: .nanoseconds(1))
         }
         .store(in: &self.cancelBag)
+        
+        self.soundManager.callInterruptPublisher.sink {[weak self] callInterrupt in
+        guard let self else { return }
+            callInterrupt == true ? self.stop() : nil
+        }
+        .store(in: &self.cancelBag)
     }
 }
 

--- a/Macro/Service/SoundManager.swift
+++ b/Macro/Service/SoundManager.swift
@@ -49,6 +49,30 @@ class SoundManager {
         
         // 더미 노드 분리
         self.engine.detach(dummyNode)
+        
+        // 전화 송/수신 시 interrupt 여부를 감지를 위한 notificationCenter 생성
+        self.setupNotifications()
+    }
+    
+    @objc func handleInterruption(notification: Notification) {
+        guard let userInfo = notification.userInfo,
+            let typeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
+            let type = AVAudioSession.InterruptionType(rawValue: typeValue) else {
+                return
+        }
+        switch type {
+        case .began:
+            print("중단됨")
+        default: ()
+        }
+    }
+    
+    func setupNotifications() {
+        let callInterruptNotificationCenter = NotificationCenter.default
+        callInterruptNotificationCenter.addObserver(self,
+                       selector: #selector(handleInterruption),
+                       name: AVAudioSession.interruptionNotification,
+                       object: AVAudioSession.sharedInstance())
     }
     
     private func configureSoundPlayers(weak: String, medium: String, strong: String) throws {


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
전화 수신, 발신 시 소리 재생 오류 해결
<!-- Close #371  -->

## 작업 내용
### 1. 전화 수신/발신 시 메트로놈 재생 중단
- NotificationCenter를 통해서 AudioSession 인터럽트 관측하도록 구현
- 오디오 인터럽트(알람, 전화) 발생 시 메트로놈 재생 중단(화면, 소리)
- MetronomeOnOffUseCase에서 화면과 소리 모두 play, stop 처리하고 있으나 인터럽트 확인은 AVFoundation을 통해서 진행하는 것으로 SoundManager에서 인터럽트 여부를 Combine으로 전달하여 중단 여부를 확인하도록 구현함
### 2. 전화 종료 후 재실행 시 오디오 재실행
- 오디오 인터럽트 종료 시 Engine 재실행 -> 시스템적으로 오락가락함
- MetronomeOnOffUseCase에서 시작 버튼을 누를 때 AudioEngine isRunning 여부 체크 후 재시작하도록 구현함

## 비고 <!-- (Optional) -->
- Beep() 실행 시 playNode 부착 과정에서 체크되는 사항임을 확인하여 내부적으로 AudioEngine.isRunning 확인하여 최초 실행 시 AudioEngine.start() 처리하고자 
### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. >
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?