### PR TITLE
[Feat] #379 BakBar에 점선으로 구분선 추가

### DIFF
--- a/Macro/Screen/MetronomeScreen/BakBarView.swift
+++ b/Macro/Screen/MetronomeScreen/BakBarView.swift
@@ -31,9 +31,20 @@ struct BakBarView: View {
     var body: some View {
         GeometryReader { geo in
             ZStack(alignment: .top) {
-                VStack(spacing: 0) {
+                ZStack(alignment: .bottom) {
                     Rectangle()
                         .foregroundStyle(isPlaying && isActive ? .orange.opacity(0.5) : .frame)
+                    
+                    Path { path in
+                        for i in 1..<3 {
+                            let y = CGFloat(i) * (geo.size.height / 3) - 0.5
+                            path.move(to: CGPoint(x: 0, y: y))
+                            path.addLine(to: CGPoint(x: geo.size.width, y: y))
+                        }
+                    }
+                    .stroke(style: StrokeStyle(lineWidth: 1, lineCap: .round, dash: [4, 4]))
+                    .foregroundColor(.bakBarDivider)
+                    
                     Rectangle()
                         .frame(height: CGFloat((geo.size.height / 3) * Double(accentHeight)))
                         .foregroundStyle(isActive

--- a/Macro/Screen/MetronomeScreen/BakBarView.swift
+++ b/Macro/Screen/MetronomeScreen/BakBarView.swift
@@ -37,12 +37,12 @@ struct BakBarView: View {
                     
                     Path { path in
                         for i in 1..<3 {
-                            let y = CGFloat(i) * (geo.size.height / 3) - 0.5
+                            let y = CGFloat(i) * (geo.size.height / 3) + 0.5
                             path.move(to: CGPoint(x: 0, y: y))
                             path.addLine(to: CGPoint(x: geo.size.width, y: y))
                         }
                     }
-                    .stroke(style: StrokeStyle(lineWidth: 1, lineCap: .round, dash: [4, 4]))
+                    .stroke(style: StrokeStyle(lineWidth: 1, dash: [2, 2]))
                     .foregroundColor(.bakBarDivider)
                     
                     Rectangle()


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
Accent 변경이 가능하다는걸 사용자가 알아차릴수 있도록 하는 장치로
BakBar에 Accent 단계를 구분하는 점선을 추가합니다.

<!-- Close #379 -->

## 작업 내용
### 1. BakBar에 점선 추가
- Path 사용해서 1/3, 2/3 지점에 점선을 그려넣음
- - 0.5는 Accent를 표현하는 주황 사각형에 가리지 않도록 점선을 굵기의 절반만큼 위로 올려주는것
- 점선 굵기 1
- 점선 마감 둥글게
- 선 4, 빈칸 4 길이 패턴

### 2. View 레이어 구조 변경
- ZStack으로 쌓여야해서 VStack을 ZStack으로 변경
- 기능차이 없음

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?