### PR TITLE
[Feat] #388 DynamicIsland, LiveActivity 수정

### DIFF
--- a/HanbaeWidget/Assets.xcassets/Text_Secondary.colorset/Contents.json
+++ b/HanbaeWidget/Assets.xcassets/Text_Secondary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF5",
+          "green" : "0xF5",
+          "red" : "0xF5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HanbaeWidget/HanbaeWidgetLiveActivity.swift
+++ b/HanbaeWidget/HanbaeWidgetLiveActivity.swift
@@ -32,8 +32,10 @@ struct HanbaeWidgetLiveActivity: Widget {
                     VStack(spacing: 0) {
                         Text("빠르기")
                             .font(.footnote)
+                            .foregroundStyle(.textSecondary)
                         Text("\(context.state.bpm)")
                             .font(.system(size: 40))
+                            .fontWeight(.medium)
                     }
                     
                     Rectangle()
@@ -43,6 +45,7 @@ struct HanbaeWidgetLiveActivity: Widget {
                     
                     VStack(alignment: .leading, spacing: 4) {
                         Image(systemName: "waveform")
+                            .font(.system(size: 17))
                         Text("\(context.state.jangdanName)")
                             .lineLimit(1)
                     }
@@ -79,8 +82,10 @@ struct HanbaeWidgetLiveActivity: Widget {
                             Spacer()
                             Text("빠르기")
                                 .font(.footnote)
+                                .foregroundStyle(.textSecondary)
                             Text("\(context.state.bpm)")
                                 .font(.system(size: 40))
+                                .fontWeight(.medium)
                                 .frame(width: 76, height: 48)
                             Spacer()
                         }
@@ -116,6 +121,7 @@ struct HanbaeWidgetLiveActivity: Widget {
                     HStack {
                         VStack(alignment: .leading, spacing: 4) {
                             Image(systemName: "waveform")
+                                .font(.system(size: 17))
                             Text("\(context.state.jangdanName)")
                                 .lineLimit(1)
                         }

--- a/Macro.xcodeproj/project.pbxproj
+++ b/Macro.xcodeproj/project.pbxproj
@@ -1035,7 +1035,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4.0;
+				MARKETING_VERSION = 2.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = Krabs.Macro;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1079,7 +1079,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4.0;
+				MARKETING_VERSION = 2.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = Krabs.Macro;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1220,7 +1220,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 2.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = Krabs.Macro.HanbaeWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1254,7 +1254,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 2.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = Krabs.Macro.HanbaeWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Macro/Screen/BuiltInJangdanScreen/BuiltinJangdanPracticeView.swift
+++ b/Macro/Screen/BuiltInJangdanScreen/BuiltinJangdanPracticeView.swift
@@ -60,7 +60,7 @@ struct BuiltinJangdanPracticeView: View {
             // 뒤로가기 chevron
             ToolbarItem(placement: .navigationBarLeading) {
                 Button(action: {
-                    self.viewModel.effect(action: .stopMetronome)
+                    self.viewModel.effect(action: .exitMetronome)
                     self.dismiss()
                 }) {
                     Image(systemName: "chevron.backward")

--- a/Macro/Screen/CustomJangdanListScreen/CustomJangdanCreateView.swift
+++ b/Macro/Screen/CustomJangdanListScreen/CustomJangdanCreateView.swift
@@ -27,7 +27,7 @@ struct CustomJangdanCreateView: View {
                 // 뒤로가기 chevron
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button {
-                        self.viewModel.effect(action: .stopMetronome)
+                        self.viewModel.effect(action: .exitMetronome)
                         backButtonAlert = true
                     } label: {
                         Image(systemName: "chevron.backward")
@@ -38,7 +38,7 @@ struct CustomJangdanCreateView: View {
                         HStack{
                             Button("취소") { }
                             Button("나가기") {
-                                self.viewModel.effect(action: .stopMetronome)
+                                self.viewModel.effect(action: .exitMetronome)
                                 router.pop()
                             }
                         }
@@ -97,7 +97,7 @@ struct CustomJangdanCreateView: View {
                                 Button("취소") { }
                                 Button("확인") {
                                     if !inputCustomJangdanName.isEmpty {
-                                        self.viewModel.effect(action: .stopMetronome)
+                                        self.viewModel.effect(action: .exitMetronome)
                                         self.viewModel.effect(action: .createCustomJangdan(newJangdanName: inputCustomJangdanName))
                                         router.pop(2)
                                     }

--- a/Macro/Screen/CustomJangdanListScreen/CustomJangdanPracticeView.swift
+++ b/Macro/Screen/CustomJangdanListScreen/CustomJangdanPracticeView.swift
@@ -76,7 +76,7 @@ struct CustomJangdanPracticeView: View {
             // 뒤로가기 chevron
             ToolbarItem(placement: .navigationBarLeading) {
                 Button {
-                    self.viewModel.effect(action: .stopMetronome)
+                    self.viewModel.effect(action: .exitMetronome)
                     router.pop()
                 } label: {
                     Image(systemName: "chevron.backward")

--- a/Macro/Screen/CustomJangdanListScreen/ViewModel/CustomJangdanPracticeViewModel.swift
+++ b/Macro/Screen/CustomJangdanListScreen/ViewModel/CustomJangdanPracticeViewModel.swift
@@ -13,11 +13,16 @@ class CustomJangdanPracticeViewModel {
     
     private var templateUseCase: TemplateUseCase
     private var metronomeOnOffUseCase: MetronomeOnOffUseCase
+    
+    private var widgetManager: WidgetManager
+    
     private var cancelbag: Set<AnyCancellable> = []
     
-    init(templateUseCase: TemplateUseCase, metronomeOnOffUseCase: MetronomeOnOffUseCase) {
+    init(templateUseCase: TemplateUseCase, metronomeOnOffUseCase: MetronomeOnOffUseCase, widgetManager: WidgetManager) {
         self.templateUseCase = templateUseCase
         self.metronomeOnOffUseCase = metronomeOnOffUseCase
+        
+        self.widgetManager = widgetManager
         
         self.templateUseCase.currentJangdanTypePublisher.sink { [weak self] jangdanType in
             guard let self else { return }
@@ -37,7 +42,7 @@ extension CustomJangdanPracticeViewModel {
     enum Action {
         case selectJangdan(jangdanName: String)
         case initialJangdan(jangdanName: String)
-        case stopMetronome
+        case exitMetronome
         case createCustomJangdan(newJangdanName: String)
         case changeSoundType
         case updateCustomJangdan(newJangdanName: String?)
@@ -50,8 +55,11 @@ extension CustomJangdanPracticeViewModel {
             self.templateUseCase.setJangdan(jangdanName: jangdanName)
         case let .initialJangdan(jangdanName):
             self.templateUseCase.setJangdan(jangdanName: jangdanName)
-        case .stopMetronome:
+        case .exitMetronome:
             self.metronomeOnOffUseCase.stop()
+            Task {
+                await self.widgetManager.endLiveActivity()
+            }
         case let .createCustomJangdan(newJangdanName):
             try! self.templateUseCase.createCustomJangdan(newJangdanName: newJangdanName)
         case .changeSoundType:

--- a/Macro/Screen/MetronomeScreen/ViewModel/MetronomeControlViewModel.swift
+++ b/Macro/Screen/MetronomeScreen/ViewModel/MetronomeControlViewModel.swift
@@ -85,7 +85,6 @@ extension MetronomeControlViewModel {
                 }
             } else {
                 self.metronomeOnOffUseCase.play()
-                self.widgetManager.startLiveActivity()
             }
         case .decreaseShortBpm:
             self.tempoUseCase.updateTempo(newBpm: self.state.bpm - 1)

--- a/Macro/Screen/MetronomeScreen/ViewModel/MetronomeControlViewModel.swift
+++ b/Macro/Screen/MetronomeScreen/ViewModel/MetronomeControlViewModel.swift
@@ -16,12 +16,16 @@ class MetronomeControlViewModel {
     private var tempoUseCase: TempoUseCase
     private var metronomeOnOffUseCase: MetronomeOnOffUseCase
     
+    private var widgetManager: WidgetManager
+    
     var timerCancellable: AnyCancellable?
     
-    init(jangdanRepository: JangdanRepository, tempoUseCase: TempoUseCase, metronomeOnOffUseCase: MetronomeOnOffUseCase) {
+    init(jangdanRepository: JangdanRepository, tempoUseCase: TempoUseCase, metronomeOnOffUseCase: MetronomeOnOffUseCase, widgetManager: WidgetManager) {
         self.jangdanRepository = jangdanRepository
         self.tempoUseCase = tempoUseCase
         self.metronomeOnOffUseCase = metronomeOnOffUseCase
+        
+        self.widgetManager = widgetManager
         
         self.timerCancellable = nil
         
@@ -76,8 +80,12 @@ extension MetronomeControlViewModel {
         case .changeIsPlaying:
             if self.state.isPlaying {
                 self.metronomeOnOffUseCase.stop()
+                Task {
+                    await self.widgetManager.endLiveActivity()
+                }
             } else {
                 self.metronomeOnOffUseCase.play()
+                self.widgetManager.startLiveActivity()
             }
         case .decreaseShortBpm:
             self.tempoUseCase.updateTempo(newBpm: self.state.bpm - 1)

--- a/Macro/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
+++ b/Macro/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
@@ -79,7 +79,6 @@ extension MetronomeViewModel {
         case selectJangdan(selectedJangdanName: String)
         case changeSobakOnOff
         case changeAccent(row: Int, daebak: Int, sobak: Int, newAccent: Accent)
-        case stopMetronome
         case disableEstimateBpm
         case changeBlinkOnOff
     }
@@ -100,11 +99,6 @@ extension MetronomeViewModel {
             self.metronomeOnOffUseCase.changeSobak()
         case let .changeAccent(row, daebak, sobak, newAccent):
             self.accentUseCase.moveNextAccent(rowIndex: row, daebakIndex: daebak, sobakIndex: sobak, to: newAccent)
-        case .stopMetronome: // 시트 변경 시 소리 중지를 위해 사용함
-            if self.state.isSobakOn {
-                self.metronomeOnOffUseCase.changeSobak()
-            }
-            self.metronomeOnOffUseCase.stop()
         case .disableEstimateBpm:
             self.tempoUseCase.finishTapping()
         case .changeBlinkOnOff:

--- a/Macro/Service/LiveActivityManager.swift
+++ b/Macro/Service/LiveActivityManager.swift
@@ -50,6 +50,10 @@ class LiveActivityManager {
             guard let self else { return }
             self.isPlaying = isPlaying
             
+            if isPlaying && Activity<HanbaeWidgetAttributes>.activities.isEmpty {
+                self.startLiveActivity()
+            }
+            
             Task {
                 await self.updateLiveActivity()
             }

--- a/Macro/Service/LiveActivityManager.swift
+++ b/Macro/Service/LiveActivityManager.swift
@@ -50,18 +50,6 @@ class LiveActivityManager {
             guard let self else { return }
             self.isPlaying = isPlaying
             
-            if isPlaying {
-                if Activity<HanbaeWidgetAttributes>.activities.isEmpty {
-                    print("이미 라이브 액티비티 없음")
-                    self.startLiveActivity()
-                } else {
-                    print("이미 라이브 액티비티 있음")
-                    Task {
-                        await self.updateLiveActivity()
-                    }
-                }
-            }
-            
             Task {
                 await self.updateLiveActivity()
             }
@@ -75,7 +63,6 @@ class LiveActivityManager {
                 } else {
                     self.metronomeOnOffUseCase.play()
                 }
-                print("hi")
             }
             .store(in: &cancelBag)
     }

--- a/Macro/Service/LiveActivityManager.swift
+++ b/Macro/Service/LiveActivityManager.swift
@@ -9,6 +9,12 @@ import Foundation
 import ActivityKit
 import Combine
 
+protocol WidgetManager {
+    func startLiveActivity()
+    func updateLiveActivity() async
+    func endLiveActivity() async
+}
+
 class LiveActivityManager {
     
     private var jangdanRepository: JangdanRepository
@@ -73,8 +79,10 @@ class LiveActivityManager {
             }
             .store(in: &cancelBag)
     }
-    
-    private func startLiveActivity() {
+}
+
+extension LiveActivityManager: WidgetManager {
+    func startLiveActivity() {
         if ActivityAuthorizationInfo().areActivitiesEnabled {
             let initialContentState = HanbaeWidgetAttributes.ContentState(bpm: self.bpm, jangdanName: self.jangdanName, isPlaying: self.isPlaying) // 동적 컨텐츠
             let activityAttributes = HanbaeWidgetAttributes() // 정적 컨텐츠
@@ -89,7 +97,7 @@ class LiveActivityManager {
         }
     }
     
-    private func endLiveActivity() async {
+    func endLiveActivity() async {
         let finalStatus = HanbaeWidgetAttributes.ContentState(bpm: self.bpm, jangdanName: self.jangdanName, isPlaying: self.isPlaying)
         let finalContent = ActivityContent(state: finalStatus, staleDate: nil)
         
@@ -99,7 +107,7 @@ class LiveActivityManager {
         }
     }
     
-    private func updateLiveActivity() async {
+    func updateLiveActivity() async {
         let status = HanbaeWidgetAttributes.ContentState(bpm: self.bpm, jangdanName: self.jangdanName, isPlaying: self.isPlaying)
         let content = ActivityContent(state: status, staleDate: nil)
         for activity in Activity<HanbaeWidgetAttributes>.activities {

--- a/Macro/System/DIContainer.swift
+++ b/Macro/System/DIContainer.swift
@@ -70,6 +70,6 @@ class DIContainer {
     private(set) var appState: AppState
     
     // Widget
-    private var widgetManager: LiveActivityManager
+    private(set) var widgetManager: WidgetManager
     
 }

--- a/Macro/System/DIContainer.swift
+++ b/Macro/System/DIContainer.swift
@@ -26,7 +26,7 @@ class DIContainer {
         self.metronomeViewModel = MetronomeViewModel(templateUseCase: self.templateUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase, tempoUseCase: self.tempoUseCase, accentUseCase: self.accentUseCase)
         
         self.controlViewModel =
-        MetronomeControlViewModel(jangdanRepository: self.jangdanDataSource, tempoUseCase: self.tempoUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase)
+        MetronomeControlViewModel(jangdanRepository: self.jangdanDataSource, tempoUseCase: self.tempoUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase, widgetManager: self.widgetManager)
         
         self.homeViewModel = HomeViewModel(metronomeOnOffUseCase: self.metronomeOnOffUseCase, dynamicIconUseCase: self.dynamicIconUseCase)
         self.customJangdanListViewModel = CustomJangdanListViewModel(templateUseCase: self.templateUseCase)

--- a/Macro/System/DIContainer.swift
+++ b/Macro/System/DIContainer.swift
@@ -21,6 +21,8 @@ class DIContainer {
         self.accentUseCase = AccentImplement(jangdanRepository: self.jangdanDataSource)
         self.dynamicIconUseCase = DynamicIconImplement()
         
+        self.widgetManager = LiveActivityManager(jangdanRepository: self.jangdanDataSource, metronomeOnOffUseCase: self.metronomeOnOffUseCase, tempoUseCase: self.tempoUseCase)
+        
         self.metronomeViewModel = MetronomeViewModel(templateUseCase: self.templateUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase, tempoUseCase: self.tempoUseCase, accentUseCase: self.accentUseCase)
         
         self.controlViewModel =
@@ -28,13 +30,11 @@ class DIContainer {
         
         self.homeViewModel = HomeViewModel(metronomeOnOffUseCase: self.metronomeOnOffUseCase, dynamicIconUseCase: self.dynamicIconUseCase)
         self.customJangdanListViewModel = CustomJangdanListViewModel(templateUseCase: self.templateUseCase)
-        self.builtInJangdanPracticeViewModel = BuiltInJangdanPracticeViewModel(templateUseCase: self.templateUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase)
+        self.builtInJangdanPracticeViewModel = BuiltInJangdanPracticeViewModel(templateUseCase: self.templateUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase, widgetManager: self.widgetManager)
         self.customJangdanPracticeViewModel = CustomJangdanPracticeViewModel(templateUseCase: self.templateUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase)
         self.customJangdanCreateViewModel = CustomJangdanCreateViewModel(templateUseCase: self.templateUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase)
         
         self.router = .init()
-        
-        self.widgetManager = LiveActivityManager(jangdanRepository: self.jangdanDataSource, metronomeOnOffUseCase: self.metronomeOnOffUseCase, tempoUseCase: self.tempoUseCase)
     }
     
     // ViewModel

--- a/Macro/System/DIContainer.swift
+++ b/Macro/System/DIContainer.swift
@@ -31,8 +31,8 @@ class DIContainer {
         self.homeViewModel = HomeViewModel(metronomeOnOffUseCase: self.metronomeOnOffUseCase, dynamicIconUseCase: self.dynamicIconUseCase)
         self.customJangdanListViewModel = CustomJangdanListViewModel(templateUseCase: self.templateUseCase)
         self.builtInJangdanPracticeViewModel = BuiltInJangdanPracticeViewModel(templateUseCase: self.templateUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase, widgetManager: self.widgetManager)
-        self.customJangdanPracticeViewModel = CustomJangdanPracticeViewModel(templateUseCase: self.templateUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase)
-        self.customJangdanCreateViewModel = CustomJangdanCreateViewModel(templateUseCase: self.templateUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase)
+        self.customJangdanPracticeViewModel = CustomJangdanPracticeViewModel(templateUseCase: self.templateUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase, widgetManager: self.widgetManager)
+        self.customJangdanCreateViewModel = CustomJangdanCreateViewModel(templateUseCase: self.templateUseCase, metronomeOnOffUseCase: self.metronomeOnOffUseCase, widgetManager: self.widgetManager)
         
         self.router = .init()
     }


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
2.4.1의 QA를 반영했습니다.

<!-- Close #388  -->

## 작업 내용
### 1. WidgetManager 인터페이스
- LiveActivity를 View에서 컨트롤할 수 있어야 한다고 판단
- 다른 ViewModel에서 인터페이스를 통해 LiveActivityManager를 컨트롤 할 수 있도록 인터페이스 추가

### 2. Metronome 화면 벗어날때 LiveActivity 종료
- BuiltinJangdanPracticeView
- CustomJangdanPracticeView
- CustomJangdanCreateView
- 위 3가지 화면을 벗어날 때 LiveActivity 종료로직 삽입

### 3. LiveActivity UI 수정
- 폰트 크기 fix
- 폰트 색상 지정
- LiveActivity에 폰트 색상 추가

### 4. 디자이너 요청 - 앱에서 재생중이 아닐때는 LiveActivity 실행되지 않게
- 메트로놈 재생시 LiveActivity 시작되는건 Publisher에서 구독해서 실행되지만
- 메트로놈 정지하면 LiveActivity도 정지되도록 구현
- MetronomeControlViewModel에 LiveActivity 정지 로직 삽입

## 비고 <!-- (Optional) -->
음악 앱은 라이브 액티비티가 아니었다네요~

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?