### PR TITLE
[Feat] #402 BPM 상한 변경

### DIFF
--- a/Macro/Domain/UseCase/TempoImplement.swift
+++ b/Macro/Domain/UseCase/TempoImplement.swift
@@ -11,6 +11,9 @@ import Foundation
 class TempoImplement {
     private var jangdanRepository: JangdanRepository
     
+    static let minBPM: Int = 10
+    static let maxBPM: Int = 300
+    
     /// 마지막 tap 시점으로부터 6초가 지났을 때 이벤트를 전달하기 위한 publisher
     @Published private var lastTappedDate: Date?
     private var isTappingSubject: PassthroughSubject<Bool, Never>
@@ -43,12 +46,12 @@ extension TempoImplement: TempoUseCase {
     func updateTempo(newBpm: Int) {
         // 사용자가 변경한 BPM을 각 장단별 데이터 객체에 저장 요청
         switch newBpm {
-        case ..<10:
-            self.jangdanRepository.updateBPM(bpm: 10)
-        case 10...200:
+        case ..<Self.minBPM:
+            self.jangdanRepository.updateBPM(bpm: Self.minBPM)
+        case Self.minBPM...Self.maxBPM:
             self.jangdanRepository.updateBPM(bpm: newBpm)
-        case 200...:
-            self.jangdanRepository.updateBPM(bpm: 200)
+        case Self.maxBPM...:
+            self.jangdanRepository.updateBPM(bpm: Self.maxBPM)
         default :
             break
         }


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
BPM 상한을 300으로 늘립니다

<!-- Close #402  -->

## 작업 내용
### 1. BPM 상한 변경
- BPM 상, 하한을 구현체의 정적변수로 저장했습니다.
- 이제 한번에 바꾸기 편해짐
- static let 인 이유는
  - static의 경우 instance마다 메모리를 차지하지 않아서 효율적
  - 어딘가 외부에서도 사용할 수 있지 않을까..


## 비고 <!-- (Optional) -->
minBPM, maxBPM을 static let으로 만들었는데

TempoImplement 라는 UseCase 구현체에 있으니까 조금 이질감이 들더라구요

BPM 이라는 모델을 만들어서 해당 값 내부에 이것저것 담아두는게 어떨까라는 생각이 진짜 잠시 들었습니다.

근데 너무 과도하게 복잡해지는거같아서 생각만함

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?