### PR TITLE
[Feat] #400 MetronomeView UI 업데이트

### DIFF
--- a/Macro/Domain/Entity/InstrumentEnum.swift
+++ b/Macro/Domain/Entity/InstrumentEnum.swift
@@ -5,7 +5,8 @@
 //  Created by jhon on 11/14/24.
 //
 
-enum Instrument: String {
+enum Instrument: String, CaseIterable {
+    case 나무
     case 북
     case 장구
 }
@@ -13,8 +14,9 @@ enum Instrument: String {
 extension Instrument {
     var defaultJangdans: [Jangdan] {
         switch self {
-        case .북: return [.진양, .중모리, .중중모리, .자진모리, .엇모리, .엇중모리, .휘모리]
         case .장구: return [.진양, .중모리, .중중모리, .자진모리, .굿거리, .동살풀이, .세마치, .엇모리, .휘모리, .긴염불, .반염불]
+        case .북: return [.진양, .중모리, .중중모리, .자진모리, .엇모리, .엇중모리, .휘모리]
+        default: return Jangdan.allCases
         }
     }
 }

--- a/Macro/Screen/BuiltInJangdanScreen/BuiltinJangdanPracticeView.swift
+++ b/Macro/Screen/BuiltInJangdanScreen/BuiltinJangdanPracticeView.swift
@@ -71,7 +71,7 @@ struct BuiltinJangdanPracticeView: View {
             
             // 장단 선택 List title
             ToolbarItem(placement: .principal) {
-                Text(jangdanName)
+                Text(self.jangdanName)
                     .font(.Body_R)
                     .foregroundStyle(.textSecondary)
                     .padding(.trailing, 6)
@@ -81,7 +81,7 @@ struct BuiltinJangdanPracticeView: View {
                 HStack {
                     Button {
                         // TODO: 데이터 초기화
-                        initialJangdanAlert = true
+                        self.initialJangdanAlert = true
                     } label: {
                         Image(systemName: "arrow.counterclockwise")
                             .aspectRatio(contentMode: .fit)
@@ -100,28 +100,17 @@ struct BuiltinJangdanPracticeView: View {
                     
                     Menu {
                         Button {
-                            self.appState.toggleBeepSound()
-                            self.viewModel.effect(action: .changeSoundType)
-                        } label: {
-                            HStack {
-                                if self.appState.isBeepSound {
-                                    Image(systemName: "checkmark")
-                                }
-                                Text("비프음으로 변환")
-                            }
-                        }
-                        Button {
-                            exportJandanAlert = true
+                            self.exportJandanAlert = true
                         } label: {
                             Text("장단 내보내기")
                         }
                         
                     } label: {
-                        Image(systemName: "ellipsis.circle")
+                        Image(systemName: "square.and.arrow.up")
                             .aspectRatio(contentMode: .fit)
                             .foregroundStyle(.textSecondary)
                     }
-                    .alert("장단 내보내기", isPresented: $exportJandanAlert) {
+                    .alert("저장 할 장단 이름", isPresented: $exportJandanAlert) {
                         TextField("장단명", text: $inputCustomJangdanName)
                             .onChange(of: inputCustomJangdanName) { oldValue, newValue in
                                 if newValue.count > 10 {
@@ -129,16 +118,19 @@ struct BuiltinJangdanPracticeView: View {
                                 }
                             }
                         HStack{
-                            Button("취소") { }
-                            Button("완료") {
+                            Button("취소", role: .cancel) {
+                                self.inputCustomJangdanName.removeAll()
+                            }
+                            
+                            Button("확인") {
                                 if !inputCustomJangdanName.isEmpty {
                                     self.viewModel.effect(action: .createCustomJangdan(newJangdanName: inputCustomJangdanName))
-                                    toastAction = true
+                                    self.toastAction = true
                                 }
                             }
                         }
                     } message: {
-                        Text("저장된 장단명을 작성해주세요.")
+                        Text("저장될 이름을 작성해주세요.")
                     }
                 }
             }

--- a/Macro/Screen/BuiltInJangdanScreen/BuiltinJangdanPracticeView.swift
+++ b/Macro/Screen/BuiltInJangdanScreen/BuiltinJangdanPracticeView.swift
@@ -71,7 +71,7 @@ struct BuiltinJangdanPracticeView: View {
             
             // 장단 선택 List title
             ToolbarItem(placement: .principal) {
-                Text(self.viewModel.state.currentJangdanName ?? "")
+                Text(self.jangdanName)
                     .font(.Body_R)
                     .foregroundStyle(.textSecondary)
                     .padding(.trailing, 6)

--- a/Macro/Screen/BuiltInJangdanScreen/BuiltinJangdanPracticeView.swift
+++ b/Macro/Screen/BuiltInJangdanScreen/BuiltinJangdanPracticeView.swift
@@ -30,10 +30,10 @@ struct BuiltinJangdanPracticeView: View {
     
     var body: some View {
         ZStack(alignment: .top) {
-            MetronomeView(viewModel: DIContainer.shared.metronomeViewModel, jangdanName: jangdanName)
+            MetronomeView(viewModel: DIContainer.shared.metronomeViewModel, jangdanName: self.jangdanName)
             
-            if toastAction {
-                Text("'\(inputCustomJangdanName)' 내보내기가 완료되었습니다.")
+            if self.toastAction {
+                Text("'\(self.inputCustomJangdanName)' 내보내기가 완료되었습니다.")
                     .font(.Body_R)
                     .padding(.horizontal, 20)
                     .padding(.vertical, 16)
@@ -49,7 +49,7 @@ struct BuiltinJangdanPracticeView: View {
                             } completion: {
                                 self.toastAction = false
                                 self.toastOpacity = 1
-                                inputCustomJangdanName = ""
+                                self.inputCustomJangdanName = ""
                             }
                         }
                     }
@@ -71,7 +71,7 @@ struct BuiltinJangdanPracticeView: View {
             
             // 장단 선택 List title
             ToolbarItem(placement: .principal) {
-                Text(self.jangdanName)
+                Text(self.viewModel.state.currentJangdanName ?? "")
                     .font(.Body_R)
                     .foregroundStyle(.textSecondary)
                     .padding(.trailing, 6)
@@ -112,9 +112,9 @@ struct BuiltinJangdanPracticeView: View {
                     }
                     .alert("저장 할 장단 이름", isPresented: $exportJandanAlert) {
                         TextField("장단명", text: $inputCustomJangdanName)
-                            .onChange(of: inputCustomJangdanName) { oldValue, newValue in
+                            .onChange(of: self.inputCustomJangdanName) { oldValue, newValue in
                                 if newValue.count > 10 {
-                                    inputCustomJangdanName = oldValue
+                                    self.inputCustomJangdanName = oldValue
                                 }
                             }
                         HStack{
@@ -123,7 +123,7 @@ struct BuiltinJangdanPracticeView: View {
                             }
                             
                             Button("확인") {
-                                if !inputCustomJangdanName.isEmpty {
+                                if !self.inputCustomJangdanName.isEmpty {
                                     self.viewModel.effect(action: .createCustomJangdan(newJangdanName: inputCustomJangdanName))
                                     self.toastAction = true
                                 }

--- a/Macro/Screen/CustomJangdanListScreen/CustomJangdanPracticeView.swift
+++ b/Macro/Screen/CustomJangdanListScreen/CustomJangdanPracticeView.swift
@@ -46,9 +46,9 @@ struct CustomJangdanPracticeView: View {
     
     var body: some View {
         ZStack(alignment: .top) {
-            MetronomeView(viewModel: DIContainer.shared.metronomeViewModel, jangdanName: jangdanName)
+            MetronomeView(viewModel: DIContainer.shared.metronomeViewModel, jangdanName: self.jangdanName)
             
-            if toastAction {
+            if self.toastAction {
                 Text(self.toastType.massage)
                     .font(.Body_R)
                     .padding(.horizontal, 20)
@@ -65,7 +65,7 @@ struct CustomJangdanPracticeView: View {
                             } completion: {
                                 self.toastAction = false
                                 self.toastOpacity = 1
-                                inputCustomJangdanName = ""
+                                self.inputCustomJangdanName = ""
                             }
                         }
                     }
@@ -77,7 +77,7 @@ struct CustomJangdanPracticeView: View {
             ToolbarItem(placement: .navigationBarLeading) {
                 Button {
                     self.viewModel.effect(action: .exitMetronome)
-                    router.pop()
+                    self.router.pop()
                 } label: {
                     Image(systemName: "chevron.backward")
                         .aspectRatio(contentMode: .fit)
@@ -88,7 +88,7 @@ struct CustomJangdanPracticeView: View {
             
             // 연습 장단 이름
             ToolbarItem(placement: .principal) {
-                Text("\(jangdanType) | \(jangdanName)")
+                Text("\(self.jangdanType) | \(self.jangdanName)")
                     .font(.Body_R)
                     .foregroundStyle(.textSecondary)
                     .lineLimit(1)
@@ -100,7 +100,7 @@ struct CustomJangdanPracticeView: View {
             ToolbarItem(placement: .topBarTrailing) {
                 HStack {
                     Button {
-                        initialJangdanAlert = true
+                        self.initialJangdanAlert = true
                     } label: {
                         Image(systemName: "arrow.counterclockwise")
                             .aspectRatio(contentMode: .fit)
@@ -153,22 +153,23 @@ struct CustomJangdanPracticeView: View {
                             .foregroundStyle(.textSecondary)
                     }
                     .alert("장단 삭제하기", isPresented: $deleteJangdanAlert) {
-                        Button("예") {
-                            deleteJangdanAlert = false
-                            self.viewModel.effect(action: .deleteCustomJangdanData(jangdanName: jangdanName))
-                            router.pop()
+                        Button("취소", role: .cancel) {
+                            self.deleteJangdanAlert = false
                         }
-                        Button("아니오") {
-                            deleteJangdanAlert = false
+                        
+                        Button("삭제", role: .destructive) {
+                            self.deleteJangdanAlert = false
+                            self.viewModel.effect(action: .deleteCustomJangdanData(jangdanName: jangdanName))
+                            self.router.pop()
                         }
                     } message: {
                         Text("현재 장단을 삭제하시겠습니까?")
                     }
                     .alert("저장 할 장단 이름", isPresented: $exportJandanAlert) {
                         TextField("이름", text: $inputCustomJangdanName)
-                            .onChange(of: inputCustomJangdanName) { oldValue, newValue in
+                            .onChange(of: self.inputCustomJangdanName) { oldValue, newValue in
                                 if newValue.count > 10 {
-                                    inputCustomJangdanName = oldValue
+                                    self.inputCustomJangdanName = oldValue
                                 }
                             }
                         HStack{
@@ -177,7 +178,7 @@ struct CustomJangdanPracticeView: View {
                             }
                             Button("확인") {
                                 if !inputCustomJangdanName.isEmpty {
-                                    self.viewModel.effect(action: .createCustomJangdan(newJangdanName: inputCustomJangdanName))
+                                    self.viewModel.effect(action: .createCustomJangdan(newJangdanName: self.inputCustomJangdanName))
                                     self.toastType = .export(jangdanName: self.inputCustomJangdanName)
                                     self.toastAction = true
                                 }
@@ -187,10 +188,10 @@ struct CustomJangdanPracticeView: View {
                         Text("저장될 이름을 작성해주세요.")
                     }
                     .alert("변경 할 장단 이름", isPresented: $updateJandanNameAlert) {
-                        TextField(jangdanName, text: $inputCustomJangdanName)
+                        TextField(self.jangdanName, text: $inputCustomJangdanName)
                             .onChange(of: inputCustomJangdanName) { oldValue, newValue in
                                 if newValue.count > 10 {
-                                    inputCustomJangdanName = oldValue
+                                    self.inputCustomJangdanName = oldValue
                                 }
                             }
                         HStack{
@@ -201,7 +202,7 @@ struct CustomJangdanPracticeView: View {
                                 if !inputCustomJangdanName.isEmpty {
                                     self.viewModel.effect(action: .updateCustomJangdan(newJangdanName: self.inputCustomJangdanName))
                                     self.viewModel.effect(action: .selectJangdan(jangdanName: self.inputCustomJangdanName))
-                                    self.jangdanName = inputCustomJangdanName
+                                    self.jangdanName = self.inputCustomJangdanName
                                     self.toastType = .changeName
                                     self.toastAction = true
                                 }

--- a/Macro/Screen/CustomJangdanListScreen/CustomJangdanPracticeView.swift
+++ b/Macro/Screen/CustomJangdanListScreen/CustomJangdanPracticeView.swift
@@ -119,25 +119,12 @@ struct CustomJangdanPracticeView: View {
                     
                     Menu {
                         Button {
-                            self.appState.toggleBeepSound()
-                            self.viewModel.effect(action: .changeSoundType)
-                        } label: {
-                            HStack {
-                                if self.appState.isBeepSound {
-                                    Image(systemName: "checkmark")
-                                }
-                                Text("비프음으로 변환")
-                            }
-                        }
-                        
-                        Button {
                             self.viewModel.effect(action: .updateCustomJangdan(newJangdanName: nil))
                             self.toastType = .save
                             self.toastAction = true
                         } label: {
                             Text("장단 저장하기")
                         }
-                        
                         
                         Button {
                             self.exportJandanAlert = true

--- a/Macro/Screen/CustomJangdanListScreen/CustomJangdanPracticeView.swift
+++ b/Macro/Screen/CustomJangdanListScreen/CustomJangdanPracticeView.swift
@@ -164,27 +164,29 @@ struct CustomJangdanPracticeView: View {
                     } message: {
                         Text("현재 장단을 삭제하시겠습니까?")
                     }
-                    .alert("장단 내보내기", isPresented: $exportJandanAlert) {
-                        TextField("장단명", text: $inputCustomJangdanName)
+                    .alert("저장 할 장단 이름", isPresented: $exportJandanAlert) {
+                        TextField("이름", text: $inputCustomJangdanName)
                             .onChange(of: inputCustomJangdanName) { oldValue, newValue in
                                 if newValue.count > 10 {
                                     inputCustomJangdanName = oldValue
                                 }
                             }
                         HStack{
-                            Button("취소") { }
-                            Button("완료") {
+                            Button("취소", role: .cancel) {
+                                self.inputCustomJangdanName.removeAll()
+                            }
+                            Button("확인") {
                                 if !inputCustomJangdanName.isEmpty {
                                     self.viewModel.effect(action: .createCustomJangdan(newJangdanName: inputCustomJangdanName))
                                     self.toastType = .export(jangdanName: self.inputCustomJangdanName)
-                                    toastAction = true
+                                    self.toastAction = true
                                 }
                             }
                         }
                     } message: {
                         Text("저장될 이름을 작성해주세요.")
                     }
-                    .alert("장단이름 변경하기", isPresented: $updateJandanNameAlert) {
+                    .alert("변경 할 장단 이름", isPresented: $updateJandanNameAlert) {
                         TextField(jangdanName, text: $inputCustomJangdanName)
                             .onChange(of: inputCustomJangdanName) { oldValue, newValue in
                                 if newValue.count > 10 {
@@ -192,8 +194,10 @@ struct CustomJangdanPracticeView: View {
                                 }
                             }
                         HStack{
-                            Button("취소") { }
-                            Button("완료") {
+                            Button("취소", role: .cancel) {
+                                self.inputCustomJangdanName.removeAll()
+                            }
+                            Button("확인") {
                                 if !inputCustomJangdanName.isEmpty {
                                     self.viewModel.effect(action: .updateCustomJangdan(newJangdanName: self.inputCustomJangdanName))
                                     self.viewModel.effect(action: .selectJangdan(jangdanName: self.inputCustomJangdanName))
@@ -204,7 +208,7 @@ struct CustomJangdanPracticeView: View {
                             }
                         }
                     } message: {
-                        Text("새로운 장단명을 작성해주세요.")
+                        Text("변경할 이름을 작성해주세요.")
                     }
                 }
             }

--- a/Macro/Screen/MetronomeScreen/MetronomeSettingControlView.swift
+++ b/Macro/Screen/MetronomeScreen/MetronomeSettingControlView.swift
@@ -8,64 +8,82 @@
 import SwiftUI
 
 struct MetronomeSettingControlView: View {
-    
     @State private var viewModel: MetronomeViewModel = DIContainer.shared.metronomeViewModel
-    @State private var isSobakOn: Bool = false
-    @State private var isBlinkOn: Bool = false
     
     var body: some View {
         HStack(spacing: 8) {
             Button {
-                self.isSobakOn.toggle()
                 self.viewModel.effect(action: .changeSobakOnOff)
             } label: {
-                HStack(spacing: 6) {
-                    Image(self.viewModel.state.currentJangdanType?.sobakSegmentCount == nil ? .listenSobak : .viewSobak)
-                        .aspectRatio(contentMode: .fit)
-                        .foregroundStyle(self.isSobakOn ? Color.buttonToggleOn : Color.textSecondary)
-                    
-                    Text(self.viewModel.state.currentJangdanType?.sobakSegmentCount == nil ? "소박 듣기" : "소박 보기")
-                        .font(.title3)
-                        .foregroundStyle(self.isSobakOn ? Color.buttonToggleOn : Color.textSecondary)
-                }
-                .padding(.vertical, 12)
-                .padding(.leading, 22)
-                .padding(.trailing, 24)
-                .frame(maxWidth: .infinity)
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(self.isSobakOn ? Color.backgroundCard : Color.buttonToggleOff)
-                        .strokeBorder(self.isSobakOn ? Color.buttonToggleOn : Color.buttonToggleOff)
-                )
+                Image(self.viewModel.state.currentJangdanType?.sobakSegmentCount == nil ? .listenSobak : .viewSobak)
+                    .aspectRatio(contentMode: .fit)
             }
+            .buttonStyle(MetronomeSettingToggleButtonStyle())
             
             Button {
-                self.isBlinkOn.toggle()
                 self.viewModel.effect(action: .changeBlinkOnOff)
             } label: {
-                HStack(spacing: 6) {
-                    Image(.flash)
-                        .aspectRatio(contentMode: .fit)
-                        .foregroundStyle(self.isBlinkOn ? Color.buttonToggleOn : Color.textSecondary)
-                    
-                    Text("화면 반짝임")
-                        .font(.title3)
-                        .foregroundStyle(self.isBlinkOn ? Color.buttonToggleOn : Color.textSecondary)
-                }
-                .padding(.vertical, 12)
-                .padding(.leading, 22)
-                .padding(.trailing, 24)
-                .frame(maxWidth: .infinity)
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(self.isBlinkOn ? Color.backgroundCard : Color.buttonToggleOff)
-                        .strokeBorder(self.isBlinkOn ? Color.buttonToggleOn : Color.buttonToggleOff)
-                )
+                Image(.flash)
+                    .aspectRatio(contentMode: .fit)
             }
+            .buttonStyle(MetronomeSettingToggleButtonStyle())
+            
+            Menu {
+                Text("장구")
+                Text("북")
+                Text("나무")
+            } label: {
+                Image(systemName: "speaker.wave.2.fill")
+            }
+            .buttonStyle(MetronomeSettingMenuButtonStyle())
         }
         .frame(maxWidth: .infinity)
         .padding(.horizontal, 16)
         .padding(.bottom, 16)
+    }
+}
+
+extension MetronomeSettingControlView {
+    private struct MetronomeSettingToggleButtonStyle: ButtonStyle {
+        @State var isOn: Bool = false
+        
+        func makeBody(configuration: Configuration) -> some View {
+            ZStack {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(isOn ? Color.backgroundCard : Color.buttonToggleOff)
+                    .strokeBorder(isOn ? Color.buttonToggleOn : Color.buttonToggleOff)
+                
+                configuration.label
+                    .font(.title3)
+                    .foregroundStyle(isOn ? Color.buttonToggleOn : Color.textSecondary)
+            }
+            .frame(height: 56)
+            .onChange(of: configuration.isPressed) { _, newValue in
+                if newValue {
+                    isOn.toggle()
+                }
+            }
+        }
+    }
+    
+    private struct MetronomeSettingMenuButtonStyle: ButtonStyle {
+        @State var isActive: Bool = false
+        
+        func makeBody(configuration: Configuration) -> some View {
+            ZStack {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(isActive ? Color.backgroundCard : Color.buttonToggleOff)
+                    .strokeBorder(isActive ? Color.buttonToggleOn : Color.buttonToggleOff)
+                
+                configuration.label
+                    .font(.title3)
+                    .foregroundStyle(isActive ? Color.buttonToggleOn : Color.textSecondary)
+            }
+            .frame(height: 56)
+            .onChange(of: configuration.isPressed) { _, newValue in
+                isActive = newValue
+            }
+        }
     }
 }
 

--- a/Macro/Screen/MetronomeScreen/MetronomeSettingControlView.swift
+++ b/Macro/Screen/MetronomeScreen/MetronomeSettingControlView.swift
@@ -38,6 +38,7 @@ struct MetronomeSettingControlView: View {
                 ForEach(Instrument.allCases, id: \.rawValue) { instrument in
                     Button {
                         self.appState.setInstrument(instrument)
+                        self.viewModel.effect(action: .changeSoundType)
                     } label: {
                         if self.appState.selectedInstrument == instrument {
                             Image(systemName: "checkmark")

--- a/Macro/Screen/MetronomeScreen/MetronomeSettingControlView.swift
+++ b/Macro/Screen/MetronomeScreen/MetronomeSettingControlView.swift
@@ -8,7 +8,13 @@
 import SwiftUI
 
 struct MetronomeSettingControlView: View {
-    @State private var viewModel: MetronomeViewModel = DIContainer.shared.metronomeViewModel
+    @State private var appState: AppState
+    @State private var viewModel: MetronomeViewModel
+    
+    init(appState: AppState, viewModel: MetronomeViewModel) {
+        self.appState = appState
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         HStack(spacing: 8) {
@@ -29,11 +35,22 @@ struct MetronomeSettingControlView: View {
             .buttonStyle(MetronomeSettingToggleButtonStyle())
             
             Menu {
-                Text("장구")
-                Text("북")
-                Text("나무")
+                ForEach(Instrument.allCases, id: \.rawValue) { instrument in
+                    Button {
+                        self.appState.setInstrument(instrument)
+                    } label: {
+                        if self.appState.selectedInstrument == instrument {
+                            Image(systemName: "checkmark")
+                        }
+                        Text(instrument.rawValue)
+                    }
+                }
             } label: {
-                Image(systemName: "speaker.wave.2.fill")
+                HStack(spacing: 6) {
+                    Image(systemName: "speaker.wave.2.fill")
+                    
+                    Text(self.appState.selectedInstrument.rawValue)
+                }
             }
             .buttonStyle(MetronomeSettingMenuButtonStyle())
         }
@@ -88,5 +105,5 @@ extension MetronomeSettingControlView {
 }
 
 #Preview {
-    MetronomeSettingControlView()
+    MetronomeSettingControlView(appState: DIContainer.shared.appState, viewModel: DIContainer.shared.metronomeViewModel)
 }

--- a/Macro/Screen/MetronomeScreen/MetronomeView.swift
+++ b/Macro/Screen/MetronomeScreen/MetronomeView.swift
@@ -42,7 +42,7 @@ struct MetronomeView: View {
             .padding(.horizontal, 8)
             
             // MARK: 2. 소박 듣기, 소박 보기 뷰
-            MetronomeSettingControlView()
+            MetronomeSettingControlView(appState: DIContainer.shared.appState, viewModel: self.viewModel)
             
             // MARK: 3. BPM 및 재생 조절 뷰
             MetronomeControlView()

--- a/Macro/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
+++ b/Macro/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
@@ -81,6 +81,7 @@ extension MetronomeViewModel {
         case changeAccent(row: Int, daebak: Int, sobak: Int, newAccent: Accent)
         case disableEstimateBpm
         case changeBlinkOnOff
+        case changeSoundType
     }
     
     func effect(action: Action) {
@@ -104,6 +105,8 @@ extension MetronomeViewModel {
         case .changeBlinkOnOff:
             self.state.isBlinkOn.toggle()
             self.metronomeOnOffUseCase.changeBlink()
+        case .changeSoundType:
+            self.metronomeOnOffUseCase.setSoundType()
         }
     }
 }

--- a/Macro/Service/SoundManager.swift
+++ b/Macro/Service/SoundManager.swift
@@ -156,16 +156,15 @@ extension SoundManager: PlaySoundInterface {
     }
     
     func setSoundType() {
-        if self.appState.isBeepSound {
+        switch self.appState.selectedInstrument {
+        case .북:
+            self.soundType = .buk
+        case .장구:
+            self.soundType = .jangu
+        case .나무:
             self.soundType = .clave
-        } else {
-            switch self.appState.selectedInstrument {
-            case .북:
-                self.soundType = .buk
-            case .장구:
-                self.soundType = .jangu
-            }
         }
+        
         
         do {
             try self.configureSoundPlayers(soundType: self.soundType)

--- a/Macro/System/AppState.swift
+++ b/Macro/System/AppState.swift
@@ -20,7 +20,8 @@ class AppState {
         let instrument = UserDefaults.standard.string(forKey: "selectedInstrument") ?? "장구"
         self.selectedInstrument = Instrument(rawValue: instrument) ?? .장구
         
-        self.isBeepSound = UserDefaults.standard.bool(forKey: "isBeepSound")
+//        self.isBeepSound = UserDefaults.standard.bool(forKey: "isBeepSound")
+        UserDefaults.standard.removeObject(forKey: "isBeepSound")
         
         self.numberOfCreatedCustomJangdan = UserDefaults.standard.integer(forKey: "numberOfCreatedCustomJangdan")
         self.numberOfEnteredJangdan = UserDefaults.standard.integer(forKey: "numberOfEnteredJangdan")
@@ -31,9 +32,6 @@ class AppState {
     
     // 선택된 악기
     private(set) var selectedInstrument: Instrument
-    
-    // 비프음 여부
-    private(set) var isBeepSound: Bool
     
     // 커스텀장단 생성 횟수
     private(set) var numberOfCreatedCustomJangdan: Int
@@ -51,11 +49,6 @@ extension AppState {
     func setInstrument(_ instrument: Instrument) {
         self.selectedInstrument = instrument
         UserDefaults.standard.set(instrument.rawValue, forKey: "selectedInstrument")
-    }
-    
-    func toggleBeepSound() {
-        self.isBeepSound.toggle()
-        UserDefaults.standard.set(self.isBeepSound, forKey: "isBeepSound")
     }
     
     func increaseCreatedCustomJangdan() {


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
MetronomeView 관련 UI를 업데이트 합니다

<!-- Close #400  -->

## 작업 내용
### 1. MetronomeSettingControlView
- 버튼의 모양이 중복되는거같아 ButtonStyle로 분리했습니다.
- 사운드 변경 버튼의 경우 Menu 는 isPressed의 작동 로직이 약간 달라 따로 만들었습니다.
- Menu 버튼에서 악기를 순차적으로 불러오기 위해
    - Instrument 열거값에 `.나무` 추가했습니다.
    - Instrument 열거값에 `caseIterable` 프로토콜 채택했습니다.

### 2. 사운드 변경 기능
- AppState의 `isBeepSound`가 필요 없어짐에 따라
- SoundManager에서 `isBeepSound`에 따른 로직 제거했습니다 
- 그냥 `isBeepSound` 필요 없어져서 다 지움
- 삭제 이후 혹시나 동일한 이름으로 UserDefault 만들까봐 실행시 "isBeepSound" 키값 삭제 로직 추가

### 3. 메뉴버튼
- 장단 연습 화면의 우측상단 메뉴버튼 수정
- 커스텀 연습 화면에서 비프음으로 전환 메뉴 삭제
- 빌트인 연습 화면에서 비프음으로 전환 메뉴 삭제
- 빌트인 연습 화면 메뉴버튼 아이콘 변경 -> square.and.arrow.up

### 4. 기타 수정
- 세팅컨트롤뷰에서 ViewModel 외부에서 주입받도록 변경
- BuiltInJangdanPracticeView 에서 변수 사용할때 self. 붙임
- BuiltInJangdanPracticeView 에서 Alert 내용 수정
- CustomJangdanPracticeView 에서 Alert 텍스트 수정

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?