### PR TITLE
[Fix] #409 재생 중 프리징 이슈

### DIFF
--- a/Macro/Screen/HomeScreen/ViewModel/HomeViewModel.swift
+++ b/Macro/Screen/HomeScreen/ViewModel/HomeViewModel.swift
@@ -45,15 +45,12 @@ class HomeViewModel {
 
 extension HomeViewModel {
     enum Action {
-        case changeSoundType
         case appEntered
         case fetchCustomJangdanData
     }
     
     func effect(action: Action) {
         switch action {
-        case .changeSoundType:
-            self.metronomeOnOffUseCase.setSoundType()
         case .appEntered:
             self.dynamicIconUseCase.setEventIconIfNeeded()
         case .fetchCustomJangdanData:

--- a/Macro/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
+++ b/Macro/Screen/MetronomeScreen/ViewModel/MetronomeViewModel.swift
@@ -51,9 +51,11 @@ class MetronomeViewModel {
         
         self.metronomeOnOffUseCase.tickPublisher.sink { [weak self] currentBakIndex in
             guard let self else { return }
-            self.state.currentSobak = currentBakIndex.0
-            self.state.currentDaebak = currentBakIndex.1
-            self.state.currentRow = currentBakIndex.2
+            Task { @MainActor in
+                self.state.currentSobak = currentBakIndex.0
+                self.state.currentDaebak = currentBakIndex.1
+                self.state.currentRow = currentBakIndex.2
+            }
         }
         .store(in: &self.cancelBag)
     }


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
재생 중 메뉴버튼 조작시 앱이 멈추는 이슈

<!-- Close #409  -->

## 작업 내용
### 1. 버그픽스
- UI 갱신이 메인스레드에서 이뤄지지 않기 때문에 프리징 발생
- 재생 중 UI 갱신은 MetronomeView의 HanbaeBoard 갱신이라고 판단
- 현재 활성화된 index를 갱신해주는 부분을 메인스레드에서 작동하도록 변경
- 해결 (아마도)

### 2. 리팩토링
- HomeView에서 소리 변경할일이 없어져서 눈에 거슬렸던 부분 삭제

## 비고 <!-- (Optional) -->
저 생성자에서 퍼블리셔들 구독하는거 별루 맘에 안드는거같아요..

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?