### PR TITLE
Fix/#414 custom jangdan crash

### DIFF
--- a/Macro/Domain/UseCase/Interface/TemplateUseCase.swift
+++ b/Macro/Domain/UseCase/Interface/TemplateUseCase.swift
@@ -16,7 +16,7 @@ protocol TemplateUseCase {
     
     func createCustomJangdan(newJangdanName: String) throws
     
-    func updateCustomJangdan(newJangdanName: String?)
+    func updateCustomJangdan(newJangdanName: String?) throws
     
     func deleteCustomJangdan(jangdanName: String)
 }

--- a/Macro/Domain/UseCase/TemplateImplement.swift
+++ b/Macro/Domain/UseCase/TemplateImplement.swift
@@ -52,7 +52,10 @@ extension TemplateImplement: TemplateUseCase {
         self.jangdanRepository.saveNewJangdan(newJangdanName: newJangdanName)
     }
     
-    func updateCustomJangdan(newJangdanName: String?) {
+    func updateCustomJangdan(newJangdanName: String?) throws {
+        if let newJangdanName, self.jangdanRepository.isRepeatedName(jangdanName: newJangdanName) {
+            throw DataError.registedName
+        }
         self.jangdanRepository.updateCustomJangdan(newJangdanName: newJangdanName)
     }
     

--- a/Macro/Domain/UseCase/TemplateImplement.swift
+++ b/Macro/Domain/UseCase/TemplateImplement.swift
@@ -46,7 +46,7 @@ extension TemplateImplement: TemplateUseCase {
     
     // MARK: - Custom Template CRUD Logic
     func createCustomJangdan(newJangdanName: String) throws {
-        guard self.jangdanRepository.isRepeatedName(jangdanName: newJangdanName) else {
+        guard !self.jangdanRepository.isRepeatedName(jangdanName: newJangdanName) else {
             throw DataError.registedName
         }
         self.jangdanRepository.saveNewJangdan(newJangdanName: newJangdanName)

--- a/Macro/Screen/BuiltInJangdanScreen/BuiltinJangdanPracticeView.swift
+++ b/Macro/Screen/BuiltInJangdanScreen/BuiltinJangdanPracticeView.swift
@@ -17,6 +17,7 @@ struct BuiltinJangdanPracticeView: View {
     private var jangdanName: String
     
     @State private var initialJangdanAlert: Bool = false
+    @State private var isRepeatedName: Bool = false
     
     @State private var exportJandanAlert: Bool = false
     @State private var inputCustomJangdanName: String = ""
@@ -125,12 +126,23 @@ struct BuiltinJangdanPracticeView: View {
                             Button("확인") {
                                 if !self.inputCustomJangdanName.isEmpty {
                                     self.viewModel.effect(action: .createCustomJangdan(newJangdanName: inputCustomJangdanName))
+                                    guard !self.viewModel.state.isRepeatedName else {
+                                        self.isRepeatedName = true
+                                        return
+                                    }
                                     self.toastAction = true
                                 }
                             }
                         }
                     } message: {
                         Text("저장될 이름을 작성해주세요.")
+                    }
+                    .alert("이미 등록된 장단 이름입니다.", isPresented: $isRepeatedName) {
+                        Button("확인") {
+                            
+                        }
+                    } message: {
+                        Text("다른 이름으로 다시 시도해주세요.")
                     }
                 }
             }

--- a/Macro/Screen/BuiltInJangdanScreen/BuiltinJangdanPracticeView.swift
+++ b/Macro/Screen/BuiltInJangdanScreen/BuiltinJangdanPracticeView.swift
@@ -139,7 +139,7 @@ struct BuiltinJangdanPracticeView: View {
                     }
                     .alert("이미 등록된 장단 이름입니다.", isPresented: $isRepeatedName) {
                         Button("확인") {
-                            
+                            self.viewModel.effect(action: .repeatedNameNoticed)
                         }
                     } message: {
                         Text("다른 이름으로 다시 시도해주세요.")

--- a/Macro/Screen/BuiltInJangdanScreen/ViewModel/BuiltInJangdanPracticeViewModel.swift
+++ b/Macro/Screen/BuiltInJangdanScreen/ViewModel/BuiltInJangdanPracticeViewModel.swift
@@ -45,7 +45,6 @@ extension BuiltInJangdanPracticeViewModel {
         case initialJangdan
         case exitMetronome
         case createCustomJangdan(newJangdanName: String)
-        case changeSoundType
     }
     
     func effect(action: Action) {
@@ -64,8 +63,6 @@ extension BuiltInJangdanPracticeViewModel {
             } catch {
                 self.state.isRepeatedName = true
             }
-        case .changeSoundType:
-            self.metronomeOnOffUseCase.setSoundType()
         }
     }
 }

--- a/Macro/Screen/BuiltInJangdanScreen/ViewModel/BuiltInJangdanPracticeViewModel.swift
+++ b/Macro/Screen/BuiltInJangdanScreen/ViewModel/BuiltInJangdanPracticeViewModel.swift
@@ -34,7 +34,6 @@ class BuiltInJangdanPracticeViewModel {
     private(set) var state: State = .init()
     
     struct State {
-        var currentJangdanName: String?
         var currentJangdanType: Jangdan?
         var isRepeatedName: Bool = false
     }

--- a/Macro/Screen/BuiltInJangdanScreen/ViewModel/BuiltInJangdanPracticeViewModel.swift
+++ b/Macro/Screen/BuiltInJangdanScreen/ViewModel/BuiltInJangdanPracticeViewModel.swift
@@ -45,6 +45,7 @@ extension BuiltInJangdanPracticeViewModel {
         case initialJangdan
         case exitMetronome
         case createCustomJangdan(newJangdanName: String)
+        case repeatedNameNoticed
     }
     
     func effect(action: Action) {
@@ -63,6 +64,8 @@ extension BuiltInJangdanPracticeViewModel {
             } catch {
                 self.state.isRepeatedName = true
             }
+        case .repeatedNameNoticed:
+            self.state.isRepeatedName = false
         }
     }
 }

--- a/Macro/Screen/BuiltInJangdanScreen/ViewModel/BuiltInJangdanPracticeViewModel.swift
+++ b/Macro/Screen/BuiltInJangdanScreen/ViewModel/BuiltInJangdanPracticeViewModel.swift
@@ -36,6 +36,7 @@ class BuiltInJangdanPracticeViewModel {
     struct State {
         var currentJangdanName: String?
         var currentJangdanType: Jangdan?
+        var isRepeatedName: Bool = false
     }
 }
 
@@ -58,7 +59,11 @@ extension BuiltInJangdanPracticeViewModel {
                 await self.widgetManager.endLiveActivity()
             }
         case let .createCustomJangdan(newJangdanName):
-            try! self.templateUseCase.createCustomJangdan(newJangdanName: newJangdanName)
+            do {
+                try self.templateUseCase.createCustomJangdan(newJangdanName: newJangdanName)
+            } catch {
+                self.state.isRepeatedName = true
+            }
         case .changeSoundType:
             self.metronomeOnOffUseCase.setSoundType()
         }

--- a/Macro/Screen/CustomJangdanListScreen/CustomJangdanCreateView.swift
+++ b/Macro/Screen/CustomJangdanListScreen/CustomJangdanCreateView.swift
@@ -18,6 +18,7 @@ struct CustomJangdanCreateView: View {
     @State private var backButtonAlert: Bool = false
     @State private var initialJangdanAlert: Bool = false
     @State private var exportJandanAlert: Bool = false
+    @State private var isRepeatedName: Bool = false
     @State private var inputCustomJangdanName: String = ""
     
     var body: some View {
@@ -94,17 +95,30 @@ struct CustomJangdanCreateView: View {
                                     }
                                 }
                             HStack{
-                                Button("취소") { }
+                                Button("취소", role: .cancel) {
+                                    self.inputCustomJangdanName.removeAll()
+                                }
                                 Button("확인") {
                                     if !inputCustomJangdanName.isEmpty {
                                         self.viewModel.effect(action: .exitMetronome)
                                         self.viewModel.effect(action: .createCustomJangdan(newJangdanName: inputCustomJangdanName))
+                                        guard !self.viewModel.state.isRepeatedName else {
+                                            self.isRepeatedName = true
+                                            return
+                                        }
                                         router.pop(2)
                                     }
                                 }
                             }
                         } message: {
                             Text("저장될 이름을 작성해주세요.")
+                        }
+                        .alert("이미 등록된 장단 이름입니다.", isPresented: $isRepeatedName) {
+                            Button("확인") {
+                                self.viewModel.effect(action: .repeatedNameNoticed)
+                            }
+                        } message: {
+                            Text("다른 이름으로 다시 시도해주세요.")
                         }
                     }
                 }

--- a/Macro/Screen/CustomJangdanListScreen/CustomJangdanListView.swift
+++ b/Macro/Screen/CustomJangdanListScreen/CustomJangdanListView.swift
@@ -89,8 +89,10 @@ struct CustomJangdanListView: View {
                 }
             }
         }
-        .task {
-            self.viewModel.effect(action: .fetchCustomJangdanData)
+        .onChange(of: self.router.path) {
+            if self.router.path.last == .customJangdanList {
+                self.viewModel.effect(action: .fetchCustomJangdanData)
+            }
         }
         .onAppear {
             if self.appState.numberOfCreatedCustomJangdan == 3 {

--- a/Macro/Screen/CustomJangdanListScreen/CustomJangdanPracticeView.swift
+++ b/Macro/Screen/CustomJangdanListScreen/CustomJangdanPracticeView.swift
@@ -37,6 +37,8 @@ struct CustomJangdanPracticeView: View {
     
     @State private var initialJangdanAlert: Bool = false
     @State private var exportJandanAlert: Bool = false
+    @State private var isRepeatedName: Bool = false
+    
     @State private var inputCustomJangdanName: String = ""
     @State private var toastAction: Bool = false
     @State private var toastOpacity: Double = 1
@@ -180,6 +182,10 @@ struct CustomJangdanPracticeView: View {
                             Button("확인") {
                                 if !inputCustomJangdanName.isEmpty {
                                     self.viewModel.effect(action: .createCustomJangdan(newJangdanName: self.inputCustomJangdanName))
+                                    guard !self.viewModel.state.isRepeatedName else {
+                                        self.isRepeatedName = true
+                                        return
+                                    }
                                     self.toastType = .export(jangdanName: self.inputCustomJangdanName)
                                     self.toastAction = true
                                 }
@@ -202,6 +208,10 @@ struct CustomJangdanPracticeView: View {
                             Button("확인") {
                                 if !inputCustomJangdanName.isEmpty {
                                     self.viewModel.effect(action: .updateCustomJangdan(newJangdanName: self.inputCustomJangdanName))
+                                    guard !self.viewModel.state.isRepeatedName else {
+                                        self.isRepeatedName = true
+                                        return
+                                    }
                                     self.viewModel.effect(action: .selectJangdan(jangdanName: self.inputCustomJangdanName))
                                     self.jangdanName = self.inputCustomJangdanName
                                     self.toastType = .changeName
@@ -211,6 +221,13 @@ struct CustomJangdanPracticeView: View {
                         }
                     } message: {
                         Text("변경할 이름을 작성해주세요.")
+                    }
+                    .alert("이미 등록된 장단 이름입니다.", isPresented: $isRepeatedName) {
+                        Button("확인") {
+                            self.viewModel.effect(action: .repeatedNameNoticed)
+                        }
+                    } message: {
+                        Text("다른 이름으로 다시 시도해주세요.")
                     }
                 }
             }

--- a/Macro/Screen/CustomJangdanListScreen/ViewModel/CustomJangdanCreateViewModel.swift
+++ b/Macro/Screen/CustomJangdanListScreen/ViewModel/CustomJangdanCreateViewModel.swift
@@ -36,6 +36,7 @@ class CustomJangdanCreateViewModel {
     
     struct State {
         var currentJangdanType: Jangdan?
+        var isRepeatedName: Bool = false
     }
 }
 
@@ -44,6 +45,7 @@ extension CustomJangdanCreateViewModel {
         case initialJangdan
         case exitMetronome
         case createCustomJangdan(newJangdanName: String)
+        case repeatedNameNoticed
     }
     
     func effect(action: Action) {
@@ -57,7 +59,13 @@ extension CustomJangdanCreateViewModel {
                 await self.widgetManager.endLiveActivity()
             }
         case let .createCustomJangdan(newJangdanName):
-            try! self.templateUseCase.createCustomJangdan(newJangdanName: newJangdanName)
+            do {
+                try self.templateUseCase.createCustomJangdan(newJangdanName: newJangdanName)
+            } catch {
+                self.state.isRepeatedName = true
+            }
+        case .repeatedNameNoticed:
+            self.state.isRepeatedName = false
         }
     }
 }

--- a/Macro/Screen/CustomJangdanListScreen/ViewModel/CustomJangdanPracticeViewModel.swift
+++ b/Macro/Screen/CustomJangdanListScreen/ViewModel/CustomJangdanPracticeViewModel.swift
@@ -35,6 +35,7 @@ class CustomJangdanPracticeViewModel {
     
     struct State {
         var currentJangdanType: Jangdan?
+        var isRepeatedName: Bool = false
     }
 }
 
@@ -46,6 +47,7 @@ extension CustomJangdanPracticeViewModel {
         case createCustomJangdan(newJangdanName: String)
         case updateCustomJangdan(newJangdanName: String?)
         case deleteCustomJangdanData(jangdanName: String)
+        case repeatedNameNoticed
     }
     
     func effect(action: Action) {
@@ -60,11 +62,21 @@ extension CustomJangdanPracticeViewModel {
                 await self.widgetManager.endLiveActivity()
             }
         case let .createCustomJangdan(newJangdanName):
-            try! self.templateUseCase.createCustomJangdan(newJangdanName: newJangdanName)
+            do {
+                try self.templateUseCase.createCustomJangdan(newJangdanName: newJangdanName)
+            } catch {
+                self.state.isRepeatedName = true
+            }
         case let .updateCustomJangdan(newJangdanName):
-            self.templateUseCase.updateCustomJangdan(newJangdanName: newJangdanName)
+            do {
+                try self.templateUseCase.updateCustomJangdan(newJangdanName: newJangdanName)
+            } catch {
+                self.state.isRepeatedName = true
+            }
         case let .deleteCustomJangdanData(jangdanName):
             self.templateUseCase.deleteCustomJangdan(jangdanName: jangdanName)
+        case .repeatedNameNoticed:
+            self.state.isRepeatedName = false
         }
     }
 }

--- a/Macro/Screen/CustomJangdanListScreen/ViewModel/CustomJangdanPracticeViewModel.swift
+++ b/Macro/Screen/CustomJangdanListScreen/ViewModel/CustomJangdanPracticeViewModel.swift
@@ -44,7 +44,6 @@ extension CustomJangdanPracticeViewModel {
         case initialJangdan(jangdanName: String)
         case exitMetronome
         case createCustomJangdan(newJangdanName: String)
-        case changeSoundType
         case updateCustomJangdan(newJangdanName: String?)
         case deleteCustomJangdanData(jangdanName: String)
     }
@@ -62,8 +61,6 @@ extension CustomJangdanPracticeViewModel {
             }
         case let .createCustomJangdan(newJangdanName):
             try! self.templateUseCase.createCustomJangdan(newJangdanName: newJangdanName)
-        case .changeSoundType:
-            self.metronomeOnOffUseCase.setSoundType()
         case let .updateCustomJangdan(newJangdanName):
             self.templateUseCase.updateCustomJangdan(newJangdanName: newJangdanName)
         case let .deleteCustomJangdanData(jangdanName):

--- a/Macro/Service/JangdanDataManager.swift
+++ b/Macro/Service/JangdanDataManager.swift
@@ -125,7 +125,7 @@ extension JangdanDataManager: JangdanRepository {
         
         do {
             let results = try context.fetch(descriptor)
-            return results.isEmpty
+            return !results.isEmpty
         } catch {
             print("중복 이름 확인 중 오류 발생: \(error.localizedDescription)")
             return true // 오류가 발생하면 기본적으로 중복된 것으로 간주


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
커스텀 장단 생성시 크래시가 발생하는 이슈를 해결했습니다.

<!-- Close #414  -->

## 작업 내용
### 1. isRepeatedName(String) -> Bool
- 지금 true일때 저장하는 처리를 하고 있음
- 중복된 이름이면 저장을 한다는 네이밍이라 수정함

### 2. 중복 이름 처리
- Alert의 버튼을 누를 경우 Alert가 기본적으로 닫힘
- 1안: 커스텀 Alert를 생성한다
- 2안: 그냥 중복인 경우 Alert를 하나 더 생성한다
- 2안으로 선택

### 3.커스텀 장단 목록 초기화
- 커스텀 장단을 생성하고 리스트로 나오면 방금 만든 장단이 안보임
- 이거 만들어진게 맞나? 의문이 들것
- List는 메모리에서 내려가지 않고 유지되는바람에 .task나 .onAppear가 작동하지 않음
- Router의 path에 발생하는 변화를 감지해서 fetch해오도록 변경

### 4. UpdateCustomJangdan
- 기존 커스텀 장단을 업데이트하는경우에도 이름이 중복되었는지 검증하는 로직 추가

## 비고 <!-- (Optional) -->
이거 뭔가 수정하면 화면 3개 건드려야하는거 에바임
BuiltInJangdanPracticeView
CustomJangdanCreateView
CustomJangdanPracticeView

### 작업 스크린샷 <!-- (Optional) -->
![IMG_4282](https://github.com/user-attachments/assets/8d12afe2-cfa1-4a81-bfc3-e13c634082e2)

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?